### PR TITLE
serializing a textBone failed in getSearchDocumentFields if valuesCache[name] is None

### DIFF
--- a/bones/textBone.py
+++ b/bones/textBone.py
@@ -305,6 +305,9 @@ class textBone( baseBone ):
 		"""
 			Returns a list of search-fields (GAE search API) for this bone.
 		"""
+		if valuesCache.get(name) is None:
+			# If adding an entry using an subskel, our value might not have been set
+			return []
 		if self.languages:
 			assert isinstance(valuesCache[name], dict), "The value shall already contain a dict, something is wrong here."
 


### PR DESCRIPTION
can happen if adding using a subSkel

(merged from https://bitbucket.org/viur/server/pull-requests/104/serializing-a-textbone-failed-in/diff)