### PR TITLE
Pass the (currently unused) error descriptions to the underlying webob

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -467,7 +467,7 @@ class BrowseHandler(webapp.RequestHandler):
 			if conf["viur.debug.traceExceptions"]:
 				raise
 			self.response.clear()
-			self.response.set_status( e.status )
+			self.response.set_status(e.status, e.descr)
 			res = None
 			if conf["viur.errorHandler"]:
 				try:


### PR DESCRIPTION
Currently, the status-code 451 (Censored) is unusable, becorse the underlying webob is too old and didn't have an error message for that code yet