### PR TITLE
Feature/optimized relations including optional one shot behavior

### DIFF
--- a/bones/bone.py
+++ b/bones/bone.py
@@ -433,6 +433,7 @@ class baseBone(object): # One Bone:
 		:rtype: bool
 		"""
 
+		# TODO: do we use the refreshed state correctly?
 		return False
 
 	def mergeFrom(self, valuesCache, boneName, otherSkel):

--- a/bones/bone.py
+++ b/bones/bone.py
@@ -419,10 +419,21 @@ class baseBone(object): # One Bone:
 		pass
 
 	def refresh(self, valuesCache, boneName, skel):
+		"""Refresh all values we might have cached from other entities.
+
+		The method should return True if there were any changes, otherwise False
+
+		:param valuesCache:
+		:type valuesCache: dict
+		:param boneName:
+		:type boneName: str
+		:param skel: The skeleton instance we're working on
+		:type skel: :class:`server.skeleton.Skeleton`
+		:returns: if that bone has new values to save
+		:rtype: bool
 		"""
-			Refresh all values we might have cached from other entities.
-		"""
-		pass
+
+		return False
 
 	def mergeFrom(self, valuesCache, boneName, otherSkel):
 		"""

--- a/bones/fileBone.py
+++ b/bones/fileBone.py
@@ -104,7 +104,7 @@ class fileBone(treeItemBone):
 				inplaceRefreshed = True  # TODO: really refreshing needed???
 			return inplaceRefreshed
 
-		if not valuesCache[boneName] or not self.oneShot:
+		if not valuesCache[boneName] or self.updateLevel == 2:
 			return
 
 		logging.info("Refreshing fileBone %s of %s" % (boneName, skel.kindName))

--- a/bones/fileBone.py
+++ b/bones/fileBone.py
@@ -53,8 +53,7 @@ class fileBone(treeItemBone):
 		return res
 
 	def refresh(self, valuesCache, boneName, skel):
-		"""
-			Refresh all values we might have cached from other entities.
+		"""Refresh all values we might have cached from other entities.
 		"""
 
 		def updateInplace(relDict):
@@ -83,15 +82,17 @@ class fileBone(treeItemBone):
 
 					logging.info("Trying to fetch entry from blobimportmap with hash %s" % oldKeyHash)
 					res = db.Get(db.Key.from_path("viur-blobimportmap", oldKeyHash))
-				except:
+				except Exception as err:
+					logging.debug(err)
 					res = None
 
 				if res and res["oldkey"] == valDict["dlkey"]:
 					valDict["dlkey"] = res["newkey"]
 					valDict["servingurl"] = res["servingurl"]
 
-					logging.info("Refreshing file dlkey %s (%s)" % (valDict["dlkey"],
-					                                                valDict["servingurl"]))
+					logging.info("Refreshing file dlkey %s (%s)" % (
+						valDict["dlkey"],
+						valDict["servingurl"]))
 				else:
 					if valDict["servingurl"]:
 						try:
@@ -99,12 +100,11 @@ class fileBone(treeItemBone):
 						except Exception as e:
 							logging.exception(e)
 
-
-		if not valuesCache[boneName]:
+		if not valuesCache[boneName] or not self.oneShot:
 			return
 
 		logging.info("Refreshing fileBone %s of %s" % (boneName, skel.kindName))
-		super(fileBone, self).refresh(valuesCache, boneName, skel)
+		superRefreshed = super(fileBone, self).refresh(valuesCache, boneName, skel)
 
 		if isinstance(valuesCache[boneName], dict):
 			updateInplace(valuesCache[boneName])
@@ -112,3 +112,5 @@ class fileBone(treeItemBone):
 		elif isinstance(valuesCache[boneName], list):
 			for k in valuesCache[boneName]:
 				updateInplace(k)
+
+		return True  # TODO: check if this is correct?

--- a/bones/numericBone.py
+++ b/bones/numericBone.py
@@ -112,3 +112,4 @@ class numericBone( baseBone ):
 	def getSearchDocumentFields(self, valuesCache, name, prefix = ""):
 		if isinstance(valuesCache.get(name), int) or isinstance(valuesCache.get(name), float):
 			return [search.NumberField(name=prefix + name, value=valuesCache[name])]
+		return list()

--- a/bones/relationalBone.py
+++ b/bones/relationalBone.py
@@ -846,7 +846,7 @@ class relationalBone(baseBone):
 				if updateInplace(key):
 					refreshed = True
 
-		return refreshed
+		return self.updateLevel == 0 or refreshed
 
 	def getSearchTags(self, values, key):
 		def getValues(res, skel, valuesCache):

--- a/bones/relationalBone.py
+++ b/bones/relationalBone.py
@@ -1,43 +1,42 @@
 # -*- coding: utf-8 -*-
+import logging
+from time import time
+
+import extjson
+
+from server import db
 from server.bones import baseBone
 from server.bones.bone import getSystemInitialized
-from server import db
 from server.errors import ReadFromClientError
 from server.utils import normalizeKey
-from google.appengine.api import search
-import extjson
-from time import time
-from datetime import datetime
-import logging
 
 
-class relationalBone( baseBone ):
-	"""
-		This is our magic class implementing relations.
+class relationalBone(baseBone):
+	"""This is our magic class implementing relations.
 
-		This implementation is read-efficient, e.g. filtering by relational-properties only costs an additional
-		small-op for each entity returned.
-		However, it costs several more write-ops for writing an entity to the db.
-		(These costs are somewhat around additional (4+len(refKeys)+len(parentKeys)) write-ops for each referenced
-		property) for multiple=True relationalBones and (4+len(refKeys)) for n:1 relations)
+	This implementation is read-efficient, e.g. filtering by relational-properties only costs an additional
+	small-op for each entity returned.
+	However, it costs several more write-ops for writing an entity to the db.
+	(These costs are somewhat around additional (4+len(refKeys)+len(parentKeys)) write-ops for each referenced
+	property) for multiple=True relationalBones and (4+len(refKeys)) for n:1 relations)
 
-		So don't use this if you expect data being read less frequently than written! (Sorry, we don't have a
-		write-efficient method yet)
-		To speedup writes to (maybe) referenced entities, information in these relations isn't updated instantly.
-		Once a skeleton is updated, a deferred task is kicked off which updates the references to
-		that skeleton (if any).
-		As a result, you might see stale data until this task has been finished.
+	So don't use this if you expect data being read less frequently than written! (Sorry, we don't have a
+	write-efficient method yet)
+	To speedup writes to (maybe) referenced entities, information in these relations isn't updated instantly.
+	Once a skeleton is updated, a deferred task is kicked off which updates the references to
+	that skeleton (if any).
+	As a result, you might see stale data until this task has been finished.
 
-		Example:
+	Example:
 
-			* Entity A references Entity B.
-			* Both have a property "name".
-			* Entity B gets updated (it name changes).
-			* As "A" has a copy of entity "B"s values, you'll see "B"s old name inside the values of the
-			  relationalBone when fetching entity A.
+		* Entity A references Entity B.
+		* Both have a property "name".
+		* Entity B gets updated (it name changes).
+		* As "A" has a copy of entity "B"s values, you'll see "B"s old name inside the values of the
+		  relationalBone when fetching entity A.
 
-		If you filter a list by relational properties, this will also use the old data! (Eg. filtering A's list by
-		B's new name won't return any result)
+	If you filter a list by relational properties, this will also use the old data! (Eg. filtering A's list by
+	B's new name won't return any result)
 	"""
 	refKeys = ["key", "name"]
 	parentKeys = ["key", "name"]
@@ -69,11 +68,11 @@ class relationalBone( baseBone ):
 		:param updateLevel: level 0==always update refkeys (old behavior), 1==update refKeys only on rebuildSearchIndex, 2==write once on set, never update again refKeys
 		:type updateLevel: int
 		"""
-		baseBone.__init__( self, *args, **kwargs )
+		baseBone.__init__(self, *args, **kwargs)
 		self.multiple = multiple
 		self.format = format
 		self.updateLevel = updateLevel
-		#self._dbValue = None #Store the original result fetched from the db here so we have that information in case a referenced entity has been deleted
+		# self._dbValue = None #Store the original result fetched from the db here so we have that information in case a referenced entity has been deleted
 
 		if kind:
 			self.kind = kind
@@ -94,7 +93,7 @@ class relationalBone( baseBone ):
 		if parentKeys:
 			if not "key" in parentKeys:
 				raise AttributeError("'key' must be included in parentKeys!")
-			self.parentKeys=parentKeys
+			self.parentKeys = parentKeys
 
 		self.using = using
 
@@ -106,20 +105,17 @@ class relationalBone( baseBone ):
 			self._refSkelCache = None
 			self._usingSkelCache = None
 
-
-
 	def setSystemInitialized(self):
 		super(relationalBone, self).setSystemInitialized()
 		from server.skeleton import RefSkel, skeletonByKind
 		self._refSkelCache = RefSkel.fromSkel(skeletonByKind(self.kind), *self.refKeys)
 		self._usingSkelCache = self.using() if self.using else None
 
-
 	def _restoreValueFromDatastore(self, val):
-		"""
-			Restores one of our values (including the Rel- and Using-Skel) from the serialized data read from the datastore
-			:param value: Json-Encoded datastore property
-			:return: Our Value (with restored RelSkel and using-Skel)
+		"""Restores one of our values (including the Rel- and Using-Skel) from the serialized data read from the datastore
+
+		:param value: Json-Encoded datastore property
+		:return: Our Value (with restored RelSkel and using-Skel)
 		"""
 		value = extjson.loads(val)
 		assert isinstance(value, dict), "Read something from the datastore thats not a dict: %s" % str(type(value))
@@ -133,7 +129,7 @@ class relationalBone( baseBone ):
 			nvalue["dest"] = value
 			value = nvalue
 
-		if "id" in value["dest"] and not("key" in value["dest"] and value["dest"]["key"]):
+		if "id" in value["dest"] and not ("key" in value["dest"] and value["dest"]["key"]):
 			value["dest"]["key"] = value["dest"]["id"]
 			del value["dest"]["id"]
 		# UNTIL HERE!
@@ -150,10 +146,9 @@ class relationalBone( baseBone ):
 			usingData = None
 		return {"dest": relSkel.getValuesCache(), "rel": usingData}
 
-
-	def unserialize( self, valuesCache, name, expando ):
+	def unserialize(self, valuesCache, name, expando):
 		if name in expando:
-			val = expando[ name ]
+			val = expando[name]
 			if self.multiple:
 				valuesCache[name] = []
 				if not val:
@@ -173,7 +168,7 @@ class relationalBone( baseBone ):
 						pass
 			else:
 				valuesCache[name] = None
-				if isinstance( val, list ) and len( val )>0:
+				if isinstance(val, list) and len(val) > 0:
 					try:
 						valuesCache[name] = self._restoreValueFromDatastore(val[0])
 					except:
@@ -190,21 +185,21 @@ class relationalBone( baseBone ):
 						valuesCache[name] = None
 		else:
 			valuesCache[name] = None
-		#if isinstance( valuesCache[name], list ):
+		# if isinstance( valuesCache[name], list ):
 		#	self._dbValue = valuesCache[name][ : ]
-		#elif isinstance( valuesCache[name], dict ):
+		# elif isinstance( valuesCache[name], dict ):
 		#	self._dbValue = dict( valuesCache[name].items() )
-		#else:
+		# else:
 		#	self._dbValue = None
 		return True
 
-	def serialize(self, valuesCache, name, entity ):
+	def serialize(self, valuesCache, name, entity):
 		if not valuesCache[name]:
-			entity.set( name, None, False )
+			entity.set(name, None, False)
 			if not self.multiple:
 				for k in entity.keys():
 					if k.startswith("%s." % name):
-						del entity[ k ]
+						del entity[k]
 		else:
 			if self.multiple:
 				res = []
@@ -223,7 +218,7 @@ class relationalBone( baseBone ):
 						usingData = None
 					r = {"rel": usingData, "dest": refData}
 					res.append(extjson.dumps(r))
-				entity.set( name, res, False )
+				entity.set(name, res, False)
 			else:
 				refSkel = self._refSkelCache
 				usingSkel = self._usingSkelCache
@@ -239,125 +234,140 @@ class relationalBone( baseBone ):
 					usingData = None
 				r = {"rel": usingData, "dest": refData}
 				entity.set(name, extjson.dumps(r), False)
-				#Copy attrs of our referenced entity in
+				# Copy attrs of our referenced entity in
 				if self.indexed:
 					if refData:
 						for k, v in refData.items():
-							entity[ "%s.dest.%s" % (name,k) ] = v
+							entity["%s.dest.%s" % (name, k)] = v
 					if usingData:
 						for k, v in usingData.items():
-							entity[ "%s.rel.%s" % (name,k) ] = v
-					#for k, v in valuesCache[name].items():
-					#	if (k in self.refKeys or any( [ k.startswith("%s." %x) for x in self.refKeys ] ) ):
-					#		entity[ "%s.%s" % (name,k) ] = v
+							entity["%s.rel.%s" % (name, k)] = v
+						# for k, v in valuesCache[name].items():
+						#	if (k in self.refKeys or any( [ k.startswith("%s." %x) for x in self.refKeys ] ) ):
+						#		entity[ "%s.%s" % (name,k) ] = v
 		return entity
 
-	def postSavedHandler( self, valuesCache, boneName, skel, key, dbfields ):
+	def postSavedHandler(self, valuesCache, boneName, skel, key, dbfields):
+		logging.debug("relationalBone.postSavedHandler: %r, %r", boneName, key)
 		if not valuesCache[boneName]:
 			values = []
-		elif isinstance( valuesCache[boneName], dict ):
-			values = [ dict( (k,v) for k,v in valuesCache[boneName].items() ) ]
+		elif isinstance(valuesCache[boneName], dict):
+			values = [dict((k, v) for k, v in valuesCache[boneName].items())]
 		else:
-			values = [ dict( (k,v) for k,v in x.items() ) for x in valuesCache[boneName] ]
+			values = [dict((k, v) for k, v in x.items()) for x in valuesCache[boneName]]
 
 		parentValues = {}
 
 		for parentKey in self.parentKeys:
 			if parentKey in dbfields:
-				parentValues[ parentKey ] = dbfields[ parentKey ]
+				parentValues[parentKey] = dbfields[parentKey]
 
-		dbVals = db.Query( "viur-relations" ).ancestor( db.Key( key ) ) #skel.kindName+"_"+self.kind+"_"+key
-		dbVals.filter("viur_src_kind =", skel.kindName )
+		dbVals = db.Query("viur-relations").ancestor(db.Key(key))  # skel.kindName+"_"+self.kind+"_"+key
+		dbVals.filter("viur_src_kind =", skel.kindName)
 		dbVals.filter("viur_dest_kind =", self.kind)
-		dbVals.filter("viur_src_property =", boneName )
+		dbVals.filter("viur_src_property =", boneName)
+
+		# TODO: new oneShot/updateLevel logic, checking if this is usable and doesn't break anything
+		try:
+			updateLevel = getattr(skel, boneName).updateLevel
+		except:
+			updateLevel = 0
 
 		for dbObj in dbVals.iter():
+			logging.debug("dbObj: %r", dbObj)
 			try:
-				if not dbObj[ "dest.key" ] in [ x["dest"]["key"] for x in values ]: #Relation has been removed
-					db.Delete( dbObj.key() )
+				if not dbObj["dest.key"] in [x["dest"]["key"] for x in values]:  # Relation has been removed
+					db.Delete(dbObj.key())
+					logging.debug("relation was removed?")
 					continue
-			except: #This entry is corrupt
-				db.Delete( dbObj.key() )
-			else: # Relation: Updated
+			except:  # This entry is corrupt
+				logging.debug("relation was removed?")
+				db.Delete(dbObj.key())
+			else:  # Relation: Updated
 				data = [x for x in values if x["dest"]["key"] == dbObj["dest.key"]][0]
-				if self.indexed: #We dont store more than key and kinds, and these dont change
-					#Write our (updated) values in
+				if self.indexed:  # We dont store more than key and kinds, and these dont change
+					# Write our (updated) values in
 					refSkel = self._refSkelCache
 					refSkel.setValuesCache(data["dest"])
 					# TODO: what about this part in terms of oneShot/updateLevel?
 					for k, v in refSkel.serialize().items():
-						dbObj[ "dest."+k ] = v
-					for k,v in parentValues.items():
-						dbObj[ "src."+k ] = v
+						dbObj["dest." + k] = v
+					for k, v in parentValues.items():
+						dbObj["src." + k] = v
 					if self.using is not None:
 						usingSkel = self._usingSkelCache
 						usingSkel.setValuesCache(data["rel"])
 						for k, v in usingSkel.serialize().items():
-							dbObj[ "rel."+k ] = v
+							dbObj["rel." + k] = v
 
-					# TODO: new oneShot/updateLevel logic, checking if this is usable and doesn't break anything
-					try:
-						updateLevel = getattr(skel, boneName).updateLevel
-					except:
-						updateLevel = 0
-					# logging.debug("postSavedHandler updateLevel: %r, %r, %r, %r", skel.kindName, self.kind, boneName, updateLevel)
-					if updateLevel == 0:
-						dbObj[ "viur_delayed_update_tag" ] = time()
+					if updateLevel < 1:
+						dbObj["viur_delayed_update_tag"] = time()
 					else:
-						dbObj[ "viur_delayed_update_tag" ] = 0
-					db.Put( dbObj )
-				values.remove( data )
+						dbObj["viur_delayed_update_tag"] = 0
+					logging.debug(
+						"postSavedHandler updateLevel: %r, %r, %r, %r, %r",
+						skel.kindName,
+						self.kind,
+						boneName,
+						updateLevel, dbObj["viur_delayed_update_tag"])
+					db.Put(dbObj)
+				values.remove(data)
 
 		# Add any new Relation
 		for val in values:
-			dbObj = db.Entity( "viur-relations" , parent=db.Key( key ) ) #skel.kindName+"_"+self.kind+"_"+key
-
-			if not self.indexed: #Dont store more than key and kinds, as they aren't used anyway
-				dbObj[ "dest.key" ] = val["dest"]["key"]
-				dbObj[ "src.key" ] = key
+			dbObj = db.Entity("viur-relations", parent=db.Key(key))  # skel.kindName+"_"+self.kind+"_"+key
+			logging.debug("newRelation: %r", val)
+			if not self.indexed:  # Dont store more than key and kinds, as they aren't used anyway
+				dbObj["dest.key"] = val["dest"]["key"]
+				dbObj["src.key"] = key
 			else:
 				refSkel = self._refSkelCache
 				refSkel.setValuesCache(val["dest"])
 				for k, v in refSkel.serialize().items():
-					dbObj[ "dest."+k ] = v
-				for k,v in parentValues.items():
-					dbObj[ "src."+k ] = v
+					dbObj["dest." + k] = v
+				for k, v in parentValues.items():
+					dbObj["src." + k] = v
 				if self.using is not None:
 					usingSkel = self._usingSkelCache
 					usingSkel.setValuesCache(val["rel"])
 					for k, v in usingSkel.serialize().items():
-						dbObj[ "rel."+k ] = v
+						dbObj["rel." + k] = v
 
-			dbObj[ "viur_delayed_update_tag" ] = time()
-			dbObj[ "viur_src_kind" ] = skel.kindName #The kind of the entry referencing
-			#dbObj[ "viur_src_key" ] = str( key ) #The key of the entry referencing
-			dbObj[ "viur_src_property" ] = boneName #The key of the bone referencing
-			#dbObj[ "viur_dest_key" ] = val["key"]
-			dbObj[ "viur_dest_kind" ] = self.kind
-			db.Put( dbObj )
+			if updateLevel < 1:
+				dbObj["viur_delayed_update_tag"] = time()
+			else:
+				dbObj["viur_delayed_update_tag"] = 0
+			logging.debug("postSavedHandler updateLevel: %r, %r, %r, %r, %r", skel.kindName, self.kind, boneName,
+			              updateLevel, dbObj["viur_delayed_update_tag"])
+			dbObj["viur_src_kind"] = skel.kindName  # The kind of the entry referencing
+			# dbObj[ "viur_src_key" ] = str( key ) #The key of the entry referencing
+			dbObj["viur_src_property"] = boneName  # The key of the bone referencing
+			# dbObj[ "viur_dest_key" ] = val["key"]
+			dbObj["viur_dest_kind"] = self.kind
+			db.Put(dbObj)
 
-	def postDeletedHandler( self, skel, key, id ):
-		db.Delete( [x for x in db.Query( "viur-relations" ).ancestor( db.Key( id ) ).run( keysOnly=True ) ] )
+	def postDeletedHandler(self, skel, key, id):
+		db.Delete([x for x in db.Query("viur-relations").ancestor(db.Key(id)).run(keysOnly=True)])
 
-	def isInvalid( self, key ):
+	def isInvalid(self, key):
 		return False
 
-	def fromClient( self, valuesCache, name, data ):
-		"""
-			Reads a value from the client.
-			If this value is valid for this bone,
-			store this value and return None.
-			Otherwise our previous value is
-			left unchanged and an error-message
-			is returned.
+	def fromClient(self, valuesCache, name, data):
+		"""Reads a value from the client.
 
-			:param name: Our name in the skeleton
-			:type name: String
-			:param data: *User-supplied* request-data
-			:type data: Dict
-			:returns: None or String
+		If this value is valid for this bone,
+		store this value and return None.
+		Otherwise our previous value is
+		left unchanged and an error-message
+		is returned.
+
+		:param name: Our name in the skeleton
+		:type name: String
+		:param data: *User-supplied* request-data
+		:type data: Dict
+		:returns: None or String
 		"""
-		#from server.skeleton import RefSkel, skeletonByKind
+		# from server.skeleton import RefSkel, skeletonByKind
 
 		oldValues = valuesCache.get(name, None)
 		valuesCache[name] = []
@@ -390,61 +400,64 @@ class relationalBone( baseBone ):
 					continue
 
 				if not idx in tmpRes:
-					tmpRes[ idx ] = {}
+					tmpRes[idx] = {}
 
-				if bname in tmpRes[ idx ]:
-					if isinstance( tmpRes[ idx ][bname], list ):
-						tmpRes[ idx ][bname].append( v )
+				if bname in tmpRes[idx]:
+					if isinstance(tmpRes[idx][bname], list):
+						tmpRes[idx][bname].append(v)
 					else:
-						tmpRes[ idx ][bname] = [ tmpRes[ idx ][bname], v ]
+						tmpRes[idx][bname] = [tmpRes[idx][bname], v]
 				else:
-					tmpRes[ idx ][bname] = v
+					tmpRes[idx][bname] = v
 
-		tmpList = [(k,v) for k,v in tmpRes.items() if "key" in v]
-		tmpList.sort( key=lambda k: k[0] )
-		tmpList = [{"reltmp":v,"dest":{"key":v["key"]}} for k,v in tmpList]
+		tmpList = [(k, v) for k, v in tmpRes.items() if "key" in v]
+		tmpList.sort(key=lambda k: k[0])
+		tmpList = [{"reltmp": v, "dest": {"key": v["key"]}} for k, v in tmpList]
 		errorDict = {}
 		forceFail = False
 		if not tmpList and self.required:
 			return "No value selected!"
 		for r in tmpList[:]:
 			# Rebuild the referenced entity data
-			isEntryFromBackup = False #If the referenced entry has been deleted, restore information from
+			isEntryFromBackup = False  # If the referenced entry has been deleted, restore information from
 			entry = None
 
 			try:
-				entry = db.Get( db.Key( r["dest"]["key"] ) )
-			except: #Invalid key or something like thatmnn
+				entry = db.Get(db.Key(r["dest"]["key"]))
+			except:  # Invalid key or something like thatmnn
 
-				logging.info( "Invalid reference key >%s< detected on bone '%s'",
-							  r["dest"]["key"], name )
+				logging.info("Invalid reference key >%s< detected on bone '%s'",
+				             r["dest"]["key"], name)
 				if isinstance(oldValues, dict):
-					if oldValues["dest"]["key"]==str(r["dest"]["key"]):
+					if oldValues["dest"]["key"] == str(r["dest"]["key"]):
 						refSkel = self._refSkelCache
 						refSkel.setValuesCache(oldValues["dest"])
 						entry = refSkel.serialize()
 						isEntryFromBackup = True
 				elif isinstance(oldValues, list):
 					for dbVal in oldValues:
-						if dbVal["dest"]["key"]==str(r["dest"]["key"]):
+						if dbVal["dest"]["key"] == str(r["dest"]["key"]):
 							refSkel = self._refSkelCache
 							refSkel.setValuesCache(dbVal["dest"])
 							entry = refSkel.serialize()
 							isEntryFromBackup = True
 				if not isEntryFromBackup:
-					if not self.multiple: #We can stop here :/
-						return( "Invalid entry selected" )
+					if not self.multiple:  # We can stop here :/
+						return ("Invalid entry selected")
 					else:
 						tmpList.remove(r)
 						continue
 
-			if not entry or (not isEntryFromBackup and not entry.key().kind()==self.kind): #Entry does not exist or has wrong type (is from another module)
+			if not entry or (
+						not isEntryFromBackup and not entry.key().kind() == self.kind):  # Entry does not exist or has wrong type (is from another module)
 				if entry:
-					logging.error("I got a key, which kind doesn't match my type! (Got: %s, my type %s)" % ( entry.key().kind(), self.kind))
+					logging.error("I got a key, which kind doesn't match my type! (Got: %s, my type %s)" % (
+						entry.key().kind(), self.kind))
 				tmpList.remove(r)
 				continue
 
-			tmp = { k: entry[k] for k in entry.keys() if (k in self.refKeys or any( [ k.startswith("%s." %x) for x in self.refKeys ] ) ) }
+			tmp = {k: entry[k] for k in entry.keys() if
+			       (k in self.refKeys or any([k.startswith("%s." % x) for x in self.refKeys]))}
 			tmp["key"] = r["dest"]["key"]
 			relSkel = self._refSkelCache
 			relSkel.setValuesCache({})
@@ -455,9 +468,9 @@ class relationalBone( baseBone ):
 			if self.using is not None:
 				refSkel = self._usingSkelCache
 				refSkel.setValuesCache({})
-				if not refSkel.fromClient( r["reltmp"] ):
-					for k,v in refSkel.errors.items():
-						errorDict[ "%s.%s.%s" % (name,tmpList.index(r),k) ] = v
+				if not refSkel.fromClient(r["reltmp"]):
+					for k, v in refSkel.errors.items():
+						errorDict["%s.%s.%s" % (name, tmpList.index(r), k)] = v
 						forceFail = True
 				r["rel"] = refSkel.getValuesCache()
 			else:
@@ -488,74 +501,78 @@ class relationalBone( baseBone ):
 		if len(errorDict.keys()):
 			return ReadFromClientError(errorDict, forceFail)
 
-	def _rewriteQuery(self, name, skel, dbFilter, rawFilter ):
-		"""
-			Rewrites a datastore query to operate on "viur-relations" instead of the original kind.
-			This is needed to perform relational queries on n:m relations.
+	def _rewriteQuery(self, name, skel, dbFilter, rawFilter):
+		"""Rewrites a datastore query to operate on "viur-relations" instead of the original kind.
+
+		This is needed to perform relational queries on n:m relations.
 		"""
 		origFilter = dbFilter.datastoreQuery
 		origSortOrders = dbFilter.getOrders()
-		if isinstance( origFilter, db.MultiQuery):
-			raise NotImplementedError("Doing a relational Query with multiple=True and \"IN or !=\"-filters is currently unsupported!")
-		dbFilter.datastoreQuery = type( dbFilter.datastoreQuery )( "viur-relations" ) #skel.kindName+"_"+self.kind+"_"+name
-		dbFilter.filter("viur_src_kind =", skel.kindName )
+		if isinstance(origFilter, db.MultiQuery):
+			raise NotImplementedError(
+				"Doing a relational Query with multiple=True and \"IN or !=\"-filters is currently unsupported!")
+		dbFilter.datastoreQuery = type(dbFilter.datastoreQuery)(
+			"viur-relations")  # skel.kindName+"_"+self.kind+"_"+name
+		dbFilter.filter("viur_src_kind =", skel.kindName)
 		dbFilter.filter("viur_dest_kind =", self.kind)
-		dbFilter.filter("viur_src_property", name )
-		if dbFilter._origCursor: #Merge the cursor in again (if any)
-			dbFilter.cursor( dbFilter._origCursor )
+		dbFilter.filter("viur_src_property", name)
+		if dbFilter._origCursor:  # Merge the cursor in again (if any)
+			dbFilter.cursor(dbFilter._origCursor)
 		if origFilter:
-			for k,v in origFilter.items(): #Merge old filters in
-				#Ensure that all non-relational-filters are in parentKeys
-				if k=="__key__":
+			for k, v in origFilter.items():  # Merge old filters in
+				# Ensure that all non-relational-filters are in parentKeys
+				if k == "__key__":
 					# We must process the key-property separately as its meaning changes as we change the datastore kind were querying
-					if isinstance( v, list ) or isinstance(v, tuple):
-						logging.warning( "Invalid filtering! Doing an relational Query on %s with multiple key= filters is unsupported!" % (name) )
+					if isinstance(v, list) or isinstance(v, tuple):
+						logging.warning(
+							"Invalid filtering! Doing an relational Query on %s with multiple key= filters is unsupported!" % (
+								name))
 						raise RuntimeError()
-					if not isinstance(v, db.Key ):
-						v = db.Key( v )
-					dbFilter.ancestor( v )
+					if not isinstance(v, db.Key):
+						v = db.Key(v)
+					dbFilter.ancestor(v)
 					continue
 				if not (k if " " not in k else k.split(" ")[0]) in self.parentKeys:
-					logging.warning( "Invalid filtering! %s is not in parentKeys of RelationalBone %s!" % (k,name) )
+					logging.warning("Invalid filtering! %s is not in parentKeys of RelationalBone %s!" % (k, name))
 					raise RuntimeError()
-				dbFilter.filter( "src.%s" % k, v )
+				dbFilter.filter("src.%s" % k, v)
 			orderList = []
-			for k,d in origSortOrders: #Merge old sort orders in
+			for k, d in origSortOrders:  # Merge old sort orders in
 				if not k in self.parentKeys:
-					logging.warning( "Invalid filtering! %s is not in parentKeys of RelationalBone %s!" % (k,name) )
+					logging.warning("Invalid filtering! %s is not in parentKeys of RelationalBone %s!" % (k, name))
 					raise RuntimeError()
-				orderList.append( ("src.%s" % k, d) )
+				orderList.append(("src.%s" % k, d))
 			if orderList:
-				dbFilter.order( *orderList )
-		return( name, skel, dbFilter, rawFilter )
+				dbFilter.order(*orderList)
+		return (name, skel, dbFilter, rawFilter)
 
-	def buildDBFilter( self, name, skel, dbFilter, rawFilter, prefix=None ):
+	def buildDBFilter(self, name, skel, dbFilter, rawFilter, prefix=None):
 		from server.skeleton import RefSkel, skeletonByKind
 		origFilter = dbFilter.datastoreQuery
 
-		if origFilter is None:  #This query is unsatisfiable
-			return( dbFilter )
+		if origFilter is None:  # This query is unsatisfiable
+			return (dbFilter)
 
-		myKeys = [ x for x in rawFilter.keys() if x.startswith( "%s." % name ) ]
+		myKeys = [x for x in rawFilter.keys() if x.startswith("%s." % name)]
 
-		if len( myKeys ) > 0 and not self.indexed:
-			logging.warning( "Invalid searchfilter! %s is not indexed!" % name )
+		if len(myKeys) > 0 and not self.indexed:
+			logging.warning("Invalid searchfilter! %s is not indexed!" % name)
 			raise RuntimeError()
 
-		if len( myKeys ) > 0: #We filter by some properties
+		if len(myKeys) > 0:  # We filter by some properties
 
-			if dbFilter.getKind()!="viur-relations" and self.multiple:
-				name, skel, dbFilter, rawFilter = self._rewriteQuery( name, skel, dbFilter, rawFilter )
+			if dbFilter.getKind() != "viur-relations" and self.multiple:
+				name, skel, dbFilter, rawFilter = self._rewriteQuery(name, skel, dbFilter, rawFilter)
 
 			relSkel = RefSkel.fromSkel(skeletonByKind(self.kind), *self.refKeys)
 
 			# Merge the relational filters in
 			for myKey in myKeys:
-				value = rawFilter[ myKey ]
+				value = rawFilter[myKey]
 
 				try:
-					unused, _type, key = myKey.split(".",2)
-					assert _type in ["dest","rel"]
+					unused, _type, key = myKey.split(".", 2)
+					assert _type in ["dest", "rel"]
 				except:
 					if self.using is None:
 						# This will be a "dest" query
@@ -575,11 +592,11 @@ class relationalBone( baseBone ):
 				if "$" in checkKey:
 					checkKey = checkKey.split("$")[0]
 
-				if _type=="dest":
+				if _type == "dest":
 
-					#Ensure that the relational-filter is in refKeys
+					# Ensure that the relational-filter is in refKeys
 					if checkKey not in self.refKeys:
-						logging.warning( "Invalid filtering! %s is not in refKeys of RelationalBone %s!" % (key,name) )
+						logging.warning("Invalid filtering! %s is not in refKeys of RelationalBone %s!" % (key, name))
 						raise RuntimeError()
 
 					# Iterate our relSkel and let these bones write their filters in
@@ -587,15 +604,16 @@ class relationalBone( baseBone ):
 						if checkKey == bname:
 							newFilter = {key: value}
 							if self.multiple:
-								bone.buildDBFilter(bname, relSkel, dbFilter, newFilter, prefix=(prefix or "")+"dest.")
+								bone.buildDBFilter(bname, relSkel, dbFilter, newFilter, prefix=(prefix or "") + "dest.")
 							else:
-								bone.buildDBFilter(bname, relSkel, dbFilter, newFilter, prefix=(prefix or "")+name+".dest.")
+								bone.buildDBFilter(bname, relSkel, dbFilter, newFilter,
+								                   prefix=(prefix or "") + name + ".dest.")
 
-				elif _type=="rel":
+				elif _type == "rel":
 
-					#Ensure that the relational-filter is in refKeys
+					# Ensure that the relational-filter is in refKeys
 					if self.using is None or checkKey not in self.using():
-						logging.warning( "Invalid filtering! %s is not a bone in 'using' of %s" % (key,name) )
+						logging.warning("Invalid filtering! %s is not a bone in 'using' of %s" % (key, name))
 						raise RuntimeError()
 
 					# Iterate our usingSkel and let these bones write their filters in
@@ -603,139 +621,144 @@ class relationalBone( baseBone ):
 						if key.startswith(bname):
 							newFilter = {key: value}
 							if self.multiple:
-								bone.buildDBFilter(bname, relSkel, dbFilter, newFilter, prefix=(prefix or "")+"rel.")
+								bone.buildDBFilter(bname, relSkel, dbFilter, newFilter, prefix=(prefix or "") + "rel.")
 							else:
-								bone.buildDBFilter(bname, relSkel, dbFilter, newFilter, prefix=(prefix or "")+name+".rel.")
+								bone.buildDBFilter(bname, relSkel, dbFilter, newFilter,
+								                   prefix=(prefix or "") + name + ".rel.")
 
 			if self.multiple:
-				dbFilter.setFilterHook( lambda s, filter, value: self.filterHook( name, s, filter, value))
-				dbFilter.setOrderHook( lambda s, orderings: self.orderHook( name, s, orderings) )
+				dbFilter.setFilterHook(lambda s, filter, value: self.filterHook(name, s, filter, value))
+				dbFilter.setOrderHook(lambda s, orderings: self.orderHook(name, s, orderings))
 
-		elif name in rawFilter and rawFilter[ name ].lower() == "none":
+		elif name in rawFilter and rawFilter[name].lower() == "none":
 			dbFilter = dbFilter.filter("%s =" % name, None)
 
 		return dbFilter
 
-	def buildDBSort( self, name, skel, dbFilter, rawFilter ):
+	def buildDBSort(self, name, skel, dbFilter, rawFilter):
 		origFilter = dbFilter.datastoreQuery
-		if origFilter is None or not "orderby" in rawFilter: #This query is unsatisfiable or not sorted
-			return( dbFilter )
-		if "orderby" in rawFilter and isinstance(rawFilter["orderby"], basestring) and rawFilter["orderby"].startswith( "%s." % name ):
-			if not dbFilter.getKind()=="viur-relations": #This query has not been rewritten (yet)
-				name, skel, dbFilter, rawFilter = self._rewriteQuery( name, skel, dbFilter, rawFilter )
+		if origFilter is None or not "orderby" in rawFilter:  # This query is unsatisfiable or not sorted
+			return (dbFilter)
+		if "orderby" in rawFilter and isinstance(rawFilter["orderby"], basestring) and rawFilter["orderby"].startswith(
+						"%s." % name):
+			if not dbFilter.getKind() == "viur-relations":  # This query has not been rewritten (yet)
+				name, skel, dbFilter, rawFilter = self._rewriteQuery(name, skel, dbFilter, rawFilter)
 			key = rawFilter["orderby"]
 			try:
 				unused, _type, param = key.split(".")
-				assert _type in ["dest","rel"]
+				assert _type in ["dest", "rel"]
 			except:
-				return( dbFilter ) #We cant parse that
-				#Ensure that the relational-filter is in refKeys
-			if _type=="dest" and not param in self.refKeys:
-				logging.warning( "Invalid filtering! %s is not in refKeys of RelationalBone %s!" % (param,name) )
+				return (dbFilter)  # We cant parse that
+			# Ensure that the relational-filter is in refKeys
+			if _type == "dest" and not param in self.refKeys:
+				logging.warning("Invalid filtering! %s is not in refKeys of RelationalBone %s!" % (param, name))
 				raise RuntimeError()
-			if _type=="rel" and (self.using is None or param not in self.using()):
-				logging.warning( "Invalid filtering! %s is not a bone in 'using' of %s" % (param,name) )
+			if _type == "rel" and (self.using is None or param not in self.using()):
+				logging.warning("Invalid filtering! %s is not a bone in 'using' of %s" % (param, name))
 				raise RuntimeError()
-			if "orderdir" in rawFilter  and rawFilter["orderdir"]=="1":
-				order = ( "%s.%s" % (_type,param), db.DESCENDING )
+			if "orderdir" in rawFilter and rawFilter["orderdir"] == "1":
+				order = ("%s.%s" % (_type, param), db.DESCENDING)
 			else:
-				order = ( "%s.%s" % (_type,param), db.ASCENDING )
-			dbFilter = dbFilter.order( order )
-			dbFilter.setFilterHook( lambda s, filter, value: self.filterHook( name, s, filter, value))
-			dbFilter.setOrderHook( lambda s, orderings: self.orderHook( name, s, orderings))
-		return( dbFilter )
+				order = ("%s.%s" % (_type, param), db.ASCENDING)
+			dbFilter = dbFilter.order(order)
+			dbFilter.setFilterHook(lambda s, filter, value: self.filterHook(name, s, filter, value))
+			dbFilter.setOrderHook(lambda s, orderings: self.orderHook(name, s, orderings))
+		return (dbFilter)
 
-	def filterHook(self, name, query, param, value ): #FIXME
-		"""
-			Hook installed by buildDbFilter.
-			This rewrites all filters added to the query after buildDbFilter has been run to match the
-			layout of our viur-relations index.
-			Also performs sanity checks wherever this query is possible at all.
+	def filterHook(self, name, query, param, value):  # FIXME
+		"""Hook installed by buildDbFilter.
+
+		This rewrites all filters added to the query after buildDbFilter has been run to match the
+		layout of our viur-relations index.
+		Also performs sanity checks wherever this query is possible at all.
 		"""
 		if param.startswith("src.") or param.startswith("dest.") or param.startswith("viur_"):
-			#This filter is already valid in our relation
-			return( param, value )
-		if param.startswith( "%s." % name):
-			#We add a constrain filtering by properties of the referenced entity
-			refKey = param.replace( "%s." % name, "" )
-			if " " in refKey: #Strip >, < or = params
-				refKey = refKey[ :refKey.find(" ")]
+			# This filter is already valid in our relation
+			return (param, value)
+		if param.startswith("%s." % name):
+			# We add a constrain filtering by properties of the referenced entity
+			refKey = param.replace("%s." % name, "")
+			if " " in refKey:  # Strip >, < or = params
+				refKey = refKey[:refKey.find(" ")]
 			if refKey not in self.refKeys:
-				logging.warning( "Invalid filtering! %s is not in refKeys of RelationalBone %s!" % (refKey,name) )
+				logging.warning("Invalid filtering! %s is not in refKeys of RelationalBone %s!" % (refKey, name))
 				raise RuntimeError()
 			if self.multiple:
-				return( param.replace( "%s." % name, "dest."), value )
+				return (param.replace("%s." % name, "dest."), value)
 			else:
-				return( param, value )
+				return (param, value)
 		else:
-			#We filter by a property of this entity
+			# We filter by a property of this entity
 			if not self.multiple:
-				#Not relational, not multiple - nothing to do here
-				return( param, value )
-			#Prepend "src."
+				# Not relational, not multiple - nothing to do here
+				return (param, value)
+			# Prepend "src."
 			srcKey = param
 			if " " in srcKey:
-				srcKey = srcKey[ : srcKey.find(" ")] #Cut <, >, and =
-			if srcKey == "__key__": #Rewrite key= filter as its meaning has changed
-				if isinstance( value, list ) or isinstance( value, tuple ):
-					logging.warning( "Invalid filtering! Doing an relational Query on %s with multiple key= filters is unsupported!" % (name) )
+				srcKey = srcKey[: srcKey.find(" ")]  # Cut <, >, and =
+			if srcKey == "__key__":  # Rewrite key= filter as its meaning has changed
+				if isinstance(value, list) or isinstance(value, tuple):
+					logging.warning(
+						"Invalid filtering! Doing an relational Query on %s with multiple key= filters is unsupported!" % (
+							name))
 					raise RuntimeError()
-				if not isinstance( value, db.Key ):
-					value = db.Key( value )
-				query.ancestor( value )
-				return( None )
+				if not isinstance(value, db.Key):
+					value = db.Key(value)
+				query.ancestor(value)
+				return (None)
 			if srcKey not in self.parentKeys:
-				logging.warning( "Invalid filtering! %s is not in parentKeys of RelationalBone %s!" % (srcKey,name) )
+				logging.warning("Invalid filtering! %s is not in parentKeys of RelationalBone %s!" % (srcKey, name))
 				raise RuntimeError()
-			return( "src.%s" % param, value )
+			return ("src.%s" % param, value)
 
-	def orderHook(self, name, query, orderings ): #FIXME
-		"""
-			Hook installed by buildDbFilter.
-			This rewrites all orderings added to the query after buildDbFilter has been run to match the
-			layout of our viur-relations index.
-			Also performs sanity checks wherever this query is possible at all.
+	def orderHook(self, name, query, orderings):  # FIXME
+		"""Hook installed by buildDbFilter.
+
+		This rewrites all orderings added to the query after buildDbFilter has been run to match the
+		layout of our viur-relations index.
+		Also performs sanity checks wherever this query is possible at all.
 		"""
 		res = []
-		if not isinstance( orderings, list) and not isinstance( orderings, tuple):
-			orderings = [ orderings ]
+		if not isinstance(orderings, list) and not isinstance(orderings, tuple):
+			orderings = [orderings]
 		for order in orderings:
-			if isinstance( order, tuple):
+			if isinstance(order, tuple):
 				orderKey = order[0]
 			else:
 				orderKey = order
 			if orderKey.startswith("dest.") or orderKey.startswith("rel.") or orderKey.startswith("src."):
-				#This is already valid for our relational index
-				res.append( order )
+				# This is already valid for our relational index
+				res.append(order)
 				continue
-			if orderKey.startswith("%s." % name ):
-				k = orderKey.replace( "%s." % name, "" )
+			if orderKey.startswith("%s." % name):
+				k = orderKey.replace("%s." % name, "")
 				if k not in self.refKeys:
-					logging.warning( "Invalid ordering! %s is not in refKeys of RelationalBone %s!" % (k,name) )
+					logging.warning("Invalid ordering! %s is not in refKeys of RelationalBone %s!" % (k, name))
 					raise RuntimeError()
 				if not self.multiple:
-					res.append( order )
+					res.append(order)
 				else:
-					if isinstance( order, tuple ):
-						res.append( ("dest.%s" % k, order[1] ) )
+					if isinstance(order, tuple):
+						res.append(("dest.%s" % k, order[1]))
 					else:
-						res.append( "dest.%s" % k )
+						res.append("dest.%s" % k)
 			else:
 				if not self.multiple:
 					# Nothing to do here
-					res.append( order )
+					res.append(order)
 					continue
 				else:
 					if orderKey not in self.parentKeys:
-						logging.warning( "Invalid ordering! %s is not in parentKeys of RelationalBone %s!" % (orderKey,name) )
+						logging.warning(
+							"Invalid ordering! %s is not in parentKeys of RelationalBone %s!" % (orderKey, name))
 						raise RuntimeError()
-					if isinstance( order, tuple ):
-						res.append( ("src.%s" % orderKey, order[1] ) )
+					if isinstance(order, tuple):
+						res.append(("src.%s" % orderKey, order[1]))
 					else:
-						res.append( "src.%s" % orderKey )
-		return( res )
+						res.append("src.%s" % orderKey)
+		return (res)
 
-	def refresh(self, valuesCache, boneName, skel):
+	def refresh(self, valuesCache, boneName, skel, updateSearchIndex=False):
 		"""Refresh all values we might have cached from other entities.
 
 		The method should return True if there were any changes, otherwise False
@@ -833,6 +856,7 @@ class relationalBone( baseBone ):
 						if tag not in res:
 							res.append(tag)
 			return res
+
 		value = values.get(key)
 		res = []
 		if not value:
@@ -851,9 +875,9 @@ class relationalBone( baseBone ):
 		return res
 
 	def getSearchDocumentFields(self, valuesCache, name, prefix=""):
+		"""Generate fields for Google Search API
 		"""
-		Generate fields for Google Search API
-		"""
+
 		def getValues(res, skel, valuesCache, searchPrefix):
 			for key, bone in skel.items():
 				if bone.searchable:
@@ -881,31 +905,31 @@ class relationalBone( baseBone ):
 
 		return res
 
-
 	def setBoneValue(self, valuesCache, boneName, value, append, *args, **kwargs):
-		"""
-			Set our value to 'value'.
-			Santy-Checks are performed; if the value is invalid, we flip our value back to its original
-			(default) value and return false.
+		"""Set our value to 'value'.
 
-			:param valuesCache: Dictionary with the current values from the skeleton we belong to
-			:type valuesCache: dict
-			:param boneName: The Bone which should be modified
-			:type boneName: str
-			:param value: The value that should be assigned. It's type depends on the type of that bone
-			:type boneName: object
-			:param append: If true, the given value is appended to the values of that bone instead of
-				replacing it. Only supported on bones with multiple=True
-			:type append: bool
-			:return: Wherever that operation succeeded or not.
-			:rtype: bool
+		Santy-Checks are performed; if the value is invalid, we flip our value back to its original
+		(default) value and return false.
+
+		:param valuesCache: Dictionary with the current values from the skeleton we belong to
+		:type valuesCache: dict
+		:param boneName: The Bone which should be modified
+		:type boneName: str
+		:param value: The value that should be assigned. It's type depends on the type of that bone
+		:type boneName: object
+		:param append: If true, the given value is appended to the values of that bone instead of
+			replacing it. Only supported on bones with multiple=True
+		:type append: bool
+		:return: Wherever that operation succeeded or not.
+		:rtype: bool
 		"""
 		from server.skeleton import RefSkel, skeletonByKind
 		def relSkelFromKey(key):
 			if not isinstance(key, db.Key):
 				key = db.Key(encoded=key)
 			if not key.kind() == self.kind:
-				logging.error("I got a key, which kind doesn't match my type! (Got: %s, my type %s)" % (key.kind(), self.kind))
+				logging.error(
+					"I got a key, which kind doesn't match my type! (Got: %s, my type %s)" % (key.kind(), self.kind))
 				return None
 			entity = db.Get(key)
 			if not entity:
@@ -914,6 +938,7 @@ class relationalBone( baseBone ):
 			relSkel = RefSkel.fromSkel(skeletonByKind(self.kind), *self.refKeys)
 			relSkel.unserialize(entity)
 			return relSkel
+
 		if append and not self.multiple:
 			raise ValueError("Bone %s is not multiple, cannot append!" % boneName)
 		if not self.multiple and not self.using:
@@ -922,26 +947,31 @@ class relationalBone( baseBone ):
 			realValue = (value, None)
 		elif not self.multiple and self.using:
 			if not isinstance(value, tuple) or len(value) != 2 or \
-				not (isinstance(value[0], basestring) or isinstance(value[0], db.Key)) or \
-				not isinstance(value[1], self.using):
-					raise ValueError("You must supply a tuple of (Database-Key, relSkel) to %s" % boneName)
+					not (isinstance(value[0], basestring) or isinstance(value[0], db.Key)) or \
+					not isinstance(value[1], self.using):
+				raise ValueError("You must supply a tuple of (Database-Key, relSkel) to %s" % boneName)
 			realValue = value
 		elif self.multiple and not self.using:
 			if not (isinstance(value, basestring) or isinstance(value, db.Key)) and not (isinstance(value, list)) \
-				and all([isinstance(x, basestring) or isinstance(x, db.Key) for x in value]):
-					raise ValueError("You must supply a Database-Key or a list hereof to %s" % boneName)
+					and all([isinstance(x, basestring) or isinstance(x, db.Key) for x in value]):
+				raise ValueError("You must supply a Database-Key or a list hereof to %s" % boneName)
 			if isinstance(value, list):
 				realValue = [(x, None) for x in value]
 			else:
 				realValue = [(value, None)]
 		else:  # which means (self.multiple and self.using)
-			if not (isinstance(value, tuple) and len(value) == 2 and \
-				        (isinstance(value[0], basestring) or isinstance(value[0], db.Key)) \
-					and isinstance(value[1], self.using)) and not (isinstance(value, list) and
-					all((isinstance(x, tuple) and len(x)==2 and \
-					(isinstance(x[0], basestring) or isinstance(x[0], db.Key)) \
-					and isinstance(x[1], self.using) for x in value))):
-						raise ValueError("You must supply (db.Key, RelSkel) or a list hereof to %s" % boneName)
+			if not (isinstance(value, tuple) and len(value) == 2 and
+				        (isinstance(value[0], basestring) or isinstance(value[0], db.Key)) and
+				        isinstance(value[1], self.using)) and not (isinstance(value, list) and
+					                                                   all((isinstance(x, tuple) and len(
+						                                                   x) == 2 and
+						                                                        (isinstance(x[0],
+						                                                                    basestring) or isinstance(
+							                                                        x[0], db.Key))
+					                                                        and isinstance(x[1],
+					                                                                       self.using)
+					                                                        for x in value))):
+				raise ValueError("You must supply (db.Key, RelSkel) or a list hereof to %s" % boneName)
 			if not isinstance(value, list):
 				realValue = [value]
 			else:
@@ -950,7 +980,10 @@ class relationalBone( baseBone ):
 			relSkel = relSkelFromKey(realValue[0])
 			if not relSkel:
 				return False
-			valuesCache[boneName] = {"dest": relSkel.getValuesCache(), "rel": realValue[1].getValuesCache() if realValue[1] else None}
+			valuesCache[boneName] = {
+				"dest": relSkel.getValuesCache(),
+				"rel": realValue[1].getValuesCache() if realValue[1] else None
+			}
 		else:
 			tmpRes = []
 			for val in realValue:
@@ -966,15 +999,17 @@ class relationalBone( baseBone ):
 				valuesCache[boneName] = tmpRes
 		return True
 
-	def getReferencedBlobs( self, valuesCache, name ):
+	def getReferencedBlobs(self, valuesCache, name):
 		"""
 			Returns the list of blob keys referenced from this bone
 		"""
+
 		def blobsFromSkel(skel, valuesCache):
 			blobList = set()
 			for key, _bone in skel.items():
 				blobList.update(_bone.getReferencedBlobs(valuesCache, key))
 			return blobList
+
 		res = set()
 		if name in valuesCache:
 			if isinstance(valuesCache[name], list):

--- a/bones/relationalBone.py
+++ b/bones/relationalBone.py
@@ -284,6 +284,7 @@ class relationalBone( baseBone ):
 					#Write our (updated) values in
 					refSkel = self._refSkelCache
 					refSkel.setValuesCache(data["dest"])
+					# TODO: what about this part in terms of oneShot/updateLevel?
 					for k, v in refSkel.serialize().items():
 						dbObj[ "dest."+k ] = v
 					for k,v in parentValues.items():
@@ -294,7 +295,7 @@ class relationalBone( baseBone ):
 						for k, v in usingSkel.serialize().items():
 							dbObj[ "rel."+k ] = v
 
-					# TODO: new oneShot logic, checking if this is usable and doesn't break anything
+					# TODO: new oneShot/updateLevel logic, checking if this is usable and doesn't break anything
 					try:
 						updateLevel = getattr(skel, boneName).updateLevel
 					except:
@@ -757,7 +758,7 @@ class relationalBone( baseBone ):
 
 			:param relDict: the dest part of an relationalBone entry
 			:type relDict: dict
-			:return: Has something changed aka refreshed?
+			:return: do we changed something aka refreshed?
 			:rtype: bool
 			"""
 			# TODO: do we use the refreshed state correctly?
@@ -818,8 +819,8 @@ class relationalBone( baseBone ):
 				refreshed = True
 
 		elif isinstance(valuesCache[boneName], list):
-			for k in valuesCache[boneName]:
-				if updateInplace(k):
+			for key in valuesCache[boneName]:
+				if updateInplace(key):
 					refreshed = True
 
 		return refreshed

--- a/bones/relationalBone.py
+++ b/bones/relationalBone.py
@@ -300,7 +300,7 @@ class relationalBone( baseBone ):
 						updateLevel = getattr(skel, boneName).updateLevel
 					except:
 						updateLevel = 0
-					logging.debug("postSavedHandler updateLevel: %r, %r, %r, %r", skel.kindName, self.kind, boneName, updateLevel)
+					# logging.debug("postSavedHandler updateLevel: %r, %r, %r, %r", skel.kindName, self.kind, boneName, updateLevel)
 					if updateLevel == 0:
 						dbObj[ "viur_delayed_update_tag" ] = time()
 					else:
@@ -802,7 +802,7 @@ class relationalBone( baseBone ):
 						continue
 					elif key in newValues:
 						# TODO: can we compare valDict values against newValues values?
-						logging.debug("comparing existing vs remote values: %r, %r", valDict.get(key), newValues.get(key))
+						# logging.debug("comparing existing vs remote values: %r, %r", valDict.get(key), newValues.get(key))
 						if valDict.get(key) != newValues.get(key):
 							inplaceRefreshed = True
 							getattr(refSkel, key).unserialize(valDict, key, newValues)
@@ -812,7 +812,7 @@ class relationalBone( baseBone ):
 		if not valuesCache[boneName] or self.updateLevel == 2:
 			return False
 
-		logging.info("Refreshing relationalBone %s of %s" % (boneName, skel.kindName))
+		# logging.info("Refreshing relationalBone %s of %s" % (boneName, skel.kindName))
 
 		if isinstance(valuesCache[boneName], dict):
 			if updateInplace(valuesCache[boneName]):

--- a/modules/file.py
+++ b/modules/file.py
@@ -33,6 +33,7 @@ class fileBaseSkel(TreeLeafSkel):
 	height = numericBone(descr="Height", indexed=True, searchable=True)
 
 	def refresh(self):
+		# TODO: do we use the refreshed state correctly?
 		# Update from blobimportmap
 		refreshed = False
 		try:
@@ -43,7 +44,7 @@ class fileBaseSkel(TreeLeafSkel):
 		if res and res["oldkey"] == self["dlkey"]:
 			self["dlkey"] = res["newkey"]
 			self["servingurl"] = res["servingurl"]
-			logging.info("Refreshing file dlkey %s (%s)" % (self["dlkey"], self["servingurl"]))
+			logging.info("Refreshing file dlkey %r %r", self["dlkey"], self["servingurl"])
 			refreshed = True
 		else:
 			currentServingUrl = self["servingurl"]
@@ -53,12 +54,10 @@ class fileBaseSkel(TreeLeafSkel):
 					if currentServingUrl != imageServingUrl:
 						self["servingurl"] = imageServingUrl
 						refreshed = True
-				except Exception as e:
-					logging.exception(e)
-		superResult = super(fileBaseSkel, self).refresh()
-		if superResult:
-			return True
-		return refreshed
+				except Exception as err:
+					logging.exception(err)
+		superRefreshed = super(fileBaseSkel, self).refresh()
+		return superRefreshed or refreshed
 
 	def preProcessBlobLocks(self, locks):
 		"""

--- a/prototypes/hierarchy.py
+++ b/prototypes/hierarchy.py
@@ -10,6 +10,7 @@ from server.prototypes import BasicApplication
 from server.skeleton import Skeleton
 from server.tasks import callDeferred
 
+
 class HierarchySkel(Skeleton):
 	parententry = baseBone(descr="Parent", visible=False, indexed=True, readOnly=True)
 	parentrepo = baseBone(descr="BaseRepo", visible=False, indexed=True, readOnly=True)
@@ -21,12 +22,21 @@ class HierarchySkel(Skeleton):
 		return dbfields
 
 	def refresh(self):
-		if self["parententry"]:
-			self["parententry"] = utils.normalizeKey(self["parententry"])
+		refreshed = False
+		if self["parentdir"]:
+			newParentDir = utils.normalizeKey(self["parentdir"])
+			if newParentDir != self["parentdir"]:
+				self["parentdir"] = newParentDir
+				refreshed = True
 		if self["parentrepo"]:
-			self["parentrepo"] = utils.normalizeKey(self["parentrepo"])
-
-		super(HierarchySkel, self).refresh()
+			newParentRepo = utils.normalizeKey(self["parentrepo"])
+			if newParentRepo != self["parentrepo"]:
+				self["parentrepo"] = newParentRepo
+				refreshed = True
+		superRefreshed = super(HierarchySkel, self).refresh()
+		if superRefreshed:
+			return True
+		return refreshed
 
 
 class Hierarchy(BasicApplication):

--- a/prototypes/hierarchy.py
+++ b/prototypes/hierarchy.py
@@ -22,6 +22,7 @@ class HierarchySkel(Skeleton):
 		return dbfields
 
 	def refresh(self):
+		# TODO: do we use the refreshed state correctly?
 		refreshed = False
 		if self["parentdir"]:
 			newParentDir = utils.normalizeKey(self["parentdir"])
@@ -34,9 +35,7 @@ class HierarchySkel(Skeleton):
 				self["parentrepo"] = newParentRepo
 				refreshed = True
 		superRefreshed = super(HierarchySkel, self).refresh()
-		if superRefreshed:
-			return True
-		return refreshed
+		return superRefreshed or refreshed
 
 
 class Hierarchy(BasicApplication):

--- a/prototypes/tree.py
+++ b/prototypes/tree.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
-from server import db, utils, errors, session, conf, securitykey
-from server import forcePost, forceSSL, exposed, internalExposed
+import logging
+from datetime import datetime
 
+from server import db, utils, errors, conf, securitykey
+from server import forcePost, forceSSL, exposed, internalExposed
+from server.bones import baseBone
 from server.prototypes import BasicApplication
-from server.bones import baseBone, numericBone
-from server.skeleton import Skeleton, skeletonByKind
+from server.skeleton import Skeleton
 from server.tasks import callDeferred
 
-from datetime import datetime
-import logging
 
 class TreeLeafSkel( Skeleton ):
 	parentdir = baseBone( descr="Parent", visible=False, indexed=True, readOnly=True )
@@ -39,11 +39,22 @@ class TreeLeafSkel( Skeleton ):
 		return res
 
 	def refresh(self):
+		refreshed = False
 		if self["parentdir"]:
-			self["parentdir"] = utils.normalizeKey(self["parentdir"])
+			newParentDir = utils.normalizeKey(self["parentdir"])
+			if newParentDir != self["parentdir"]:
+				self["parentdir"] = newParentDir
+				refreshed = True
 		if self["parentrepo"]:
-			self["parentrepo"] = utils.normalizeKey(self["parentrepo"])
-		super( TreeLeafSkel, self ).refresh()
+			newParentRepo = utils.normalizeKey(self["parentrepo"])
+			if newParentRepo != self["parentrepo"]:
+				self["parentrepo"] = newParentRepo
+				refreshed = True
+		superRefreshed = super(TreeLeafSkel, self).refresh()
+		if superRefreshed:
+			return True
+		return refreshed
+
 
 class TreeNodeSkel( TreeLeafSkel ):
 	pass

--- a/prototypes/tree.py
+++ b/prototypes/tree.py
@@ -39,6 +39,7 @@ class TreeLeafSkel( Skeleton ):
 		return res
 
 	def refresh(self):
+		# TODO: do we use the refreshed state correctly?
 		refreshed = False
 		if self["parentdir"]:
 			newParentDir = utils.normalizeKey(self["parentdir"])
@@ -51,9 +52,7 @@ class TreeLeafSkel( Skeleton ):
 				self["parentrepo"] = newParentRepo
 				refreshed = True
 		superRefreshed = super(TreeLeafSkel, self).refresh()
-		if superRefreshed:
-			return True
-		return refreshed
+		return superRefreshed or refreshed
 
 
 class TreeNodeSkel( TreeLeafSkel ):

--- a/skeleton.py
+++ b/skeleton.py
@@ -751,7 +751,6 @@ class Skeleton(BaseSkeleton):
 			fields = []
 
 			for boneName, bone in skel.items():
-				logging.debug("boneName, bone: %r, %r", boneName, bone)
 				if bone.searchable:
 					fields.extend(bone.getSearchDocumentFields(self.valuesCache, boneName))
 
@@ -1114,8 +1113,9 @@ def processChunk(module, compact, cursor, allCount=0, notify=None):
 			if compact == "YES":
 				raise NotImplementedError() #FIXME: This deletes the __currentKey__ property..
 				skel.delete()
-			skel.refresh()
-			skel.toDB(clearUpdateTag=True)
+			# TODO: is Skeleton.refresh already in such a good shape to trust the return value or do we even split refresh?
+			if skel.refresh():
+				skel.toDB(clearUpdateTag=True)
 		except Exception as e:
 			logging.error("Updating %s failed" % str(key) )
 			logging.exception( e )

--- a/skeleton.py
+++ b/skeleton.py
@@ -1044,8 +1044,6 @@ def updateRelations(destID, minChangeTime, cursor=None):
 		if srcBone.refresh(srcEntry.valuesCache, srcBoneName, srcEntry):
 			logging.debug("updateRelations: saving entry %r in kind %r because of bone %r", srcEntry["key"], srcEntry.kindName, srcBoneName)
 			srcEntry.toDB(clearUpdateTag=True)
-		srcRel["viur_delayed_update_tag"] = 0
-		db.Put(srcRel)
 	if len(updateList) == 5:
 		updateRelations(destID, minChangeTime, updateListQuery.getCursor().urlsafe())
 
@@ -1113,7 +1111,7 @@ def processChunk(module, compact, cursor, allCount=0, notify=None):
 			if compact == "YES":
 				raise NotImplementedError() #FIXME: This deletes the __currentKey__ property..
 				skel.delete()
-			# TODO: is Skeleton.refresh already in such a good shape to trust the return value or do we even split refresh?
+			# TODO: is Skeleton.refresh in class hierarchy already in such a good shape to trust the return value or do we even split refresh?
 			if skel.refresh():
 				skel.toDB(clearUpdateTag=True)
 		except Exception as err:

--- a/skeleton.py
+++ b/skeleton.py
@@ -1116,9 +1116,9 @@ def processChunk(module, compact, cursor, allCount=0, notify=None):
 			# TODO: is Skeleton.refresh already in such a good shape to trust the return value or do we even split refresh?
 			if skel.refresh():
 				skel.toDB(clearUpdateTag=True)
-		except Exception as e:
+		except Exception as err:
 			logging.error("Updating %s failed" % str(key) )
-			logging.exception( e )
+			logging.exception(e)
 			raise
 	newCursor = query.getCursor()
 	logging.info("END processChunk %s, %d records refreshed" % (module, count))


### PR DESCRIPTION
We want to extend the relationalBone class with an updateLevel flag.

That flag indicates if and under which circumstances its refKeys should be updated.

* updateLevel=0 reflects the old/existing behavior to always update refKeys.
* updateLevel=1 updates the refKeys only on updateSearchIndex
* updateLevel=2 will only set refKeys once on add new entities and if the relation is set on save, but never updates refKeys on edit.

This is just a initial draft and is subject to changes before merging into develop