### PR TITLE
Fixing bug in dateBone.serialize()

### DIFF
--- a/bones/dateBone.py
+++ b/bones/dateBone.py
@@ -226,7 +226,7 @@ class dateBone( baseBone ):
 		return( res )
 
 	def serialize( self, valuesCache, name, entity ):
-		res = valuesCache[name]
+		res = valuesCache.get(name)
 		if res:
 			res = self.readLocalized( datetime.now().strptime( res.strftime( "%d.%m.%Y %H:%M:%S" ), "%d.%m.%Y %H:%M:%S"  ) )
 		entity.set( name, res, self.indexed )


### PR DESCRIPTION
This bug only came up when using a dateBone inside a RelSkel with ViUR 2.1.
In ViUR 2.0, where it was previously developed with, the bug did not raise.
This fixes the issue by simply returning None when no value is provided.