### PR TITLE
Bugfix for stringBone not existing in DB

### DIFF
--- a/bones/stringBone.py
+++ b/bones/stringBone.py
@@ -129,8 +129,7 @@ class stringBone( baseBone ):
 			:type expando: :class:`server.db.Entity`
 		"""
 		if not self.languages:
-			if name in expando:
-				valuesCache[name] = expando[name]
+			valuesCache[name] = expando.get(name)
 		else:
 			valuesCache[name] = LanguageWrapper( self.languages )
 			for lang in self.languages:


### PR DESCRIPTION
Fixing the bug that comes up when a DB entry has no defaultValue and the value even is not set in the database, causing that it does not exist in the valuesCache.