### PR TITLE
Fixing baseBone.buildDBFilter()

### DIFF
--- a/bones/bone.py
+++ b/bones/bone.py
@@ -270,7 +270,7 @@ class baseBone(object): # One Bone:
 
 		for key in myKeys:
 			value = rawFilter[ key ]
-			tmpdata = key.partition("$")
+			tmpdata = key.split("$")
 
 			if len( tmpdata ) > 2:
 				if isinstance( value, list ):


### PR DESCRIPTION
This always came into the case "if len( tmpdata ) > 2:" below, because key.partition("$") always returns a 3-item tuple, but the structural logic was created to deal with the result of a split() function call.