### PR TITLE
Fixed a bug that may causes an skeleton defined in server to take pre…

### DIFF
--- a/skeleton.py
+++ b/skeleton.py
@@ -434,7 +434,7 @@ class MetaSkel(MetaBaseSkel):
 			relOldFileName = inspect.getfile(MetaBaseSkel._skelCache[cls.kindName]).replace(os.getcwd(), "")
 			if relNewFileName.strip(os.path.sep).startswith("server"):
 				# The currently processed skeleton is from the server.* package
-				pass
+				return
 			elif relOldFileName.strip(os.path.sep).startswith("server"):
 				# The old one was from server - override it
 				MetaBaseSkel._skelCache[cls.kindName] = cls


### PR DESCRIPTION
…cedence over the one defined by the application

We must stop processing a new skeleton class if we allready have one initialized for that given kind and the current one is from the server package (instead of putting it's reference into the cache)