### PR TITLE
Hotfix for PR #32, required for v2.2 release

### DIFF
--- a/db.py
+++ b/db.py
@@ -453,7 +453,7 @@ class Query( object ):
 			filter, value = r
 
 		# Cast keys into string
-		if isinstance(value, datastore_types.Key):
+		if filter != datastore_types.KEY_SPECIAL_PROPERTY and isinstance(value, datastore_types.Key):
 			value = str(value)
 
 		if value!=None and (filter.endswith(" !=") or filter.lower().endswith(" in")):


### PR DESCRIPTION
This is a serious hotfix for a problem that only comes up when using
db.KEY_SPECIAL_PROPERTY in the filter, in this case, setting the filter
property in line 483 raises an exception that a db.Key property is required,
rather than a string.

This hotfix only converts the db.Key into str for further filter if
db.KEY_SPECIAL_PROPERTY is not explicitly filtered.