### PR TITLE
Handling of non-string values in selectBone values, Bugfix for fix_translateSelectBonesInJsonRender

### DIFF
--- a/render/json/default.py
+++ b/render/json/default.py
@@ -57,7 +57,7 @@ class DefaultRender(object):
 
 		elif bone.type == "select" or bone.type.startswith("select."):
 			ret.update({
-				"values": [(k, _(v)) for k, v in bone.values.items()],
+				"values": [(k, _(v) if isinstance(v, basestring) else v) for k, v in bone.values.items()],
 				"multiple": bone.multiple,
 			})
 


### PR DESCRIPTION
This is a fix for 3a004975adb9755959e006f5e6243150fc1b759d, which causes error 500 when the values-attribute of a selectBone contains non-string values...