### PR TITLE
Adding serialBone()

### DIFF
--- a/bones/__init__.py
+++ b/bones/__init__.py
@@ -22,3 +22,4 @@ from server.bones.selectCountryBone import selectCountryBone
 from server.bones.emailBone import emailBone
 from server.bones.randomSliceBone import randomSliceBone
 from server.bones.spatialBone import spatialBone
+from server.bones.serialBone import serialBone

--- a/bones/serialBone.py
+++ b/bones/serialBone.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+from server import errors
+from server.bones import baseBone
+
+class serialBone(baseBone):
+	type = "serial"
+
+	def __init__(self, validChars="0123456789", invalidChars=None, minLength=2, maxLength = None,
+	                fill=None, align=None, *args, **kwargs):
+		super(serialBone, self).__init__(*args, **kwargs)
+		self.validChars = validChars
+		self.invalidChars = invalidChars
+		self.minLength = minLength
+		self.maxLength = maxLength
+
+		assert not fill or len(fill) == 1, "fill may only be one character long!"
+		self.fill = fill
+
+		if self.fill and align is None:
+			align = "right"
+
+		assert not align or align in ["left", "right"], "align must be 'left', 'right' or None."
+		self.align = align
+
+	def format(self, value):
+		if not self.align:
+			return value
+
+		if self.minLength:
+			length = self.minLength
+		elif self.maxLength:
+			length = self.maxLength
+
+			if self.fill and len(value) > length:
+				if self.align == "right":
+					while value.startswith(self.fill):
+						value = value[1:]
+				else:
+					while value.endswith(self.fill):
+						value = value[:1]
+		else:
+			return value
+
+		fills = "".join([self.fill for _ in range(len(value), length)])
+		return fills + value if self.align == "right" else value + fills
+
+	def isInvalid(self, value):
+		for pos, ch in enumerate(value):
+			if (self.validChars and ch not in self.validChars
+				or self.invalidChars and ch in self.invalidChars):
+				return _(u"'{{char}}' at position {{pos}} is not allowed", char=ch, pos=pos + 1)
+
+		if self.minLength is not None and len(value) < self.minLength:
+			return _(u"Value is too short, at least {{min}} characters allowed", min=self.minLength)
+		elif self.maxLength is not None and len(value) > self.maxLength:
+			return _(u"Value is too long, exceeds maximum of {{max}} characters", max=self.maxLength)
+
+		return None
+
+	def fromClient(self, valuesCache, name, data):
+		value = data.get(name)
+
+		if value:
+			value = self.format(value)
+			err = self.isInvalid(value)
+
+			if err:
+				return errors.ReadFromClientError({name: err}, True)
+				#return err
+
+		elif self.required:
+			return _(u"No value entered")
+
+		valuesCache[name] = value
+		return None

--- a/render/json/default.py
+++ b/render/json/default.py
@@ -85,6 +85,15 @@ class DefaultRender(object):
 				"multiple": bone.multiple,
 				"languages": bone.languages
 			})
+		elif bone.type == "serial" or bone.type.startswith("serial."):
+			ret.update({
+				"minLength": bone.minLength,
+				"maxLength": bone.maxLength,
+				"validChars": bone.validChars,
+				"invalidChars": bone.invalidChars,
+				"fill": bone.fill,
+				"align": bone.align
+			})
 
 		return ret
 


### PR DESCRIPTION
The serialBone is a bone that can be used for serial numbers, codes, or other, related content having an optional minimum or maximum length. Minimum length can be filled up with a fill-char and aligned left or right.

There is a related branch in ViUR vi to handle this kind of bone.