### PR TITLE
Adding filterRelationalBone()

### DIFF
--- a/bones/__init__.py
+++ b/bones/__init__.py
@@ -9,7 +9,7 @@ from server.bones.colorBone import colorBone
 from server.bones.credentialBone import credentialBone
 from server.bones.selectBone import selectBone, selectOneBone, selectMultiBone, selectAccessBone
 from server.bones.booleanBone import booleanBone
-from server.bones.relationalBone import relationalBone
+from server.bones.relationalBone import relationalBone, filterRelationalBone
 from server.bones.treeItemBone import treeItemBone
 from server.bones.treeDirBone import treeDirBone
 from server.bones.hierarchyBone import hierarchyBone


### PR DESCRIPTION
This kind of bone is working like an usual relationalBone, except that it has the capability to use a list or run a callback-function that returns a list to retrieve reference keys whose entries are permitted. Entries that do not fit into this set are filtered out when read, and inserted in when written, so that data remains consistent.