### PR TITLE
Fixing the ViUR logo path error.css

### DIFF
--- a/resources/css/error/error.css
+++ b/resources/css/error/error.css
@@ -55,7 +55,7 @@ a:active {text-decoration: none; color: #cc0000;}
 .clear {clear: both;display: block;overflow: hidden;visibility: hidden;width: 0;height: 0;}
 
 .logo {position: relative;
-       background: url(/ressources/meta/viur-logo-error.png);
+       background: url(/resources/meta/viur-logo-error.png);
        width: 140px;
        height: 150px;
        top: -3px;


### PR DESCRIPTION
This little, tiny correction would make displaying error messages with a ViUR logo, which is the way it was always meant to be but never got focused before I found it by accident ;-)

This is the way it could look like..
![image](https://user-images.githubusercontent.com/16870072/40437820-ab05d4f8-5eb6-11e8-860c-098f1f7dbb53.png)
