### PR TITLE
Ignore empty search parameter

### DIFF
--- a/db.py
+++ b/db.py
@@ -396,7 +396,7 @@ class Query( object ):
 			logging.exception(e)
 			self.datastoreQuery = None
 			return( self )
-		if "search" in filters:
+		if "search" in filters and filters["search"]:
 			if isinstance( filters["search"], list ):
 				taglist = [ "".join([y for y in unicode(x).lower() if y in conf["viur.searchValidChars"] ] ) for x in filters["search"] ]
 			else:


### PR DESCRIPTION
Currently, if an empty search parameter is supplied and we are not using the google search api we'll filter by viur_search_tags="" - which can never happen and will always return an empty result set