### PR TITLE
unified templates, removed camelcase, errorpage improved

### DIFF
--- a/resources/js/viur-forms.js
+++ b/resources/js/viur-forms.js
@@ -8,14 +8,13 @@ $(document).ready(function () {
         $("input[name='" + realBoneName + "']").val(val);
     }
 
-    $(".js_viur_bones_date_doubleinput").each(function () {
+    $(".js-viur-bones-date-doubleinput").each(function () {
         $("input[name='" + $(this).attr("name") + "-date']").change(function () {
             viurBonesDateUpdate($(this).attr("name"));
         });
         $("input[name='" + $(this).attr("name") + "-time']").change(function () {
             viurBonesDateUpdate($(this).attr("name"));
         })
-
     });
 
     // ---- Relational.Treeitem.File Bones ----
@@ -23,18 +22,18 @@ $(document).ready(function () {
     function viurBonesFileCreateNewInputGroup(reordableArea) {
         // Creates the HTML that represents one file inside a multiple file bone
         var tpl = "";
-        tpl += '<div class="vi-file inputGroup js_viur_bones_file_reordableItem" data-multiple="1" draggable="true">';
-        tpl += '<div class="vi-fileMultiBone-previewImg"></div>';
+        tpl += '<div class="vi-file input-group js-viur-bones-file-reordable-item" data-multiple="1" draggable="true">';
+        tpl += '<div class="vi-file-multi-bone-preview-img"></div>';
         tpl += '<span class="input"></span>';
-        tpl += '<button class="btn icon edit js_viur_bones_file_uploadFileButton" type="button">Bearbeiten</button>';
-        tpl += '<button class="btn icon cancel btn-vDanger js_viur_bones_file_removeFile" type="button">Entfernen</button>'
+        tpl += '<button class="btn icon edit js-viur-bones-file-upload-file-button" type="button">Bearbeiten</button>';
+        tpl += '<button class="btn icon cancel btn-vDanger js-viur-bones-file-remove-file" type="button">Entfernen</button>'
         tpl += '<span class="uploader"></span>';
         tpl += '<input type="hidden" name="' + reordableArea.data("name") + '.' + reordableArea.children().length + '.key" value="">';
         tpl += '</div>';
         var res = $(tpl);
         viurBonesFileRebindInputGroupEvents(res);
-        viurBonesFileRebindFileRemoveButton(res.find(".js_viur_bones_file_removeFile"));
-        viurBonesFileRebindFileUploadButton(res.find(".js_viur_bones_file_uploadFileButton"));
+        viurBonesFileRebindFileRemoveButton(res.find(".js-viur-bones-file-remove-file"));
+        viurBonesFileRebindFileUploadButton(res.find(".js-viur-bones-file-upload-file-button"));
         return res;
     }
 
@@ -51,14 +50,14 @@ $(document).ready(function () {
                 inputGroup.find("span[class='input']").html("");
                 inputGroup.find("span[class='uploader']").children().remove();
                 inputGroup.find("input[type='hidden']").val("");
-                inputGroup.toggleClass("isEmpty", true);
+                inputGroup.toggleClass("is-empty", true);
                 viurBonesFileUploadIn(inputGroup, ulElement.get()[0].files[0], false);
             });
             ulElement.click();
         });
     }
 
-    viurBonesFileRebindFileUploadButton($(".js_viur_bones_file_uploadFileButton"));
+    viurBonesFileRebindFileUploadButton($(".js-viur-bones-file-upload-file-button"));
 
     function viurBonesFileRebindFileRemoveButton(elems) {
         // Ensure that the delete button inside inputGroups works
@@ -72,20 +71,19 @@ $(document).ready(function () {
                 inputGroup.find("span[class='input']").html("");
                 inputGroup.find("span[class='uploader']").children().remove();
                 inputGroup.find("input[type='hidden']").val("");
-                inputGroup.find("div[class~='vi-fileMultiBone-previewImg'], div[class~='vi-fileBone-previewImg']").css("background-image", "");
-                inputGroup.toggleClass("isEmpty", true);
+                inputGroup.find("div[class~='vi-file-multi-bone-preview-img'], div[class~='vi-file-bone-preview-img']").css("background-image", "");
+                inputGroup.toggleClass("is-empty", true);
             }
-
         });
     }
 
-    viurBonesFileRebindFileRemoveButton($(".js_viur_bones_file_removeFile"));
+    viurBonesFileRebindFileRemoveButton($(".js-viur-bones-file-remove-file"));
 
     function viurBonesFileRebindInputGroupEvents(elems) {
         // Attaches the events needed to handle delete, upload & drag'n'drop inside an inputGroup
         elems.bind("dragstart", function (evt) {
             $(this).toggleClass("reodableAreaItemIsDragged", true);
-            // Our dragable elements don't have an id, so we'll use the index from our input
+            // Our draggable elements don't have an id, so we'll use the index from our input
             // field to identify the object which gets dragged later on
             evt.originalEvent.dataTransfer.setData("text", $(evt.target).find("input[type='hidden']").attr("name"));
         }).bind("dragend", function (evt) {
@@ -93,7 +91,7 @@ $(document).ready(function () {
         });
     }
 
-    viurBonesFileRebindInputGroupEvents($(".js_viur_bones_file_reordableItem"));
+    viurBonesFileRebindInputGroupEvents($(".js-viur-bones-file-reordable-item"));
 
 
     function viurBonesFileUploadIn(inputGroup, file, removeGroupOnFailure) {
@@ -114,12 +112,12 @@ $(document).ready(function () {
                 inputGroup.find("span[class='uploader']").children().remove();
                 inputGroup.find("input[type='hidden']").val(fileData.key);
                 if (fileData.servingurl) {
-                    inputGroup.find("div[class~='vi-fileMultiBone-previewImg'], div[class~='vi-fileBone-previewImg']").css("background-image", "url("+fileData.servingurl+"=s150)")
+                    inputGroup.find("div[class~='vi-file-multi-bone-preview-img'], div[class~='vi-file-bone-preview-img']").css("background-image", "url("+fileData.servingurl+"=s150)")
                 } else {
-                    inputGroup.find("div[class~='vi-fileMultiBone-previewImg'], div[class~='vi-fileBone-previewImg']").css("background-image", "")
+                    inputGroup.find("div[class~='vi-file-multi-bone-preview-img'], div[class~='vi-file-bone-preview-img']").css("background-image", "")
                 }
 
-                inputGroup.toggleClass("isEmpty", false);
+                inputGroup.toggleClass("is-empty", false);
             }
         }
 
@@ -149,7 +147,7 @@ $(document).ready(function () {
         });
     }
 
-    $(".js_viur_bones_file_reordableArea").bind("dragover", function (evt) {
+    $(".js-viur-bones-file-reordable-area").bind("dragover", function (evt) {
         // Determine where the drop should be placed and show an visual indicator
         var afterElement = null;
         $(this).children().each(function (idx) {
@@ -221,7 +219,7 @@ $(document).ready(function () {
     });
 
 
-    $(".js_viur_bones_file_addFiles").click(function () {
+    $(".js-viur-bones-file-add-files").click(function () {
         // The user clicked the button to add new files to a multiple=True fileBone. Open the chooser,
         // create a new inputGroup for each and start uploading
         var oldThis = $(this);
@@ -240,7 +238,7 @@ $(document).ready(function () {
         ulElement.click();
     });
 
-    $(".js_viur_bones_file_uploadableInputGroup").bind("dragenter dragover", function (evt) {
+    $(".js-viur-bones-file-uploadable-input-group").bind("dragenter dragover", function (evt) {
         // For multiple=False bones we'll also accept all drag events by default
         evt.preventDefault();
         return false;
@@ -266,51 +264,49 @@ $(document).ready(function () {
         });
     }
 
-    viurBonesStrRebindDeleteStrButton($(".js_viur_bones_str_delteSingleStrWrapper"));
+    viurBonesStrRebindDeleteStrButton($(".js-viur-bones-str-delte-single-str-wrapper"));
 
 
-    $(".js_viur_bones_str_languageSelector").change(function () {
+    $(".js-viur-bones-str-language-selector").change(function () {
         // Show the corresponding text field(s)
-        $(".js_viur_bones_str_languageWrapper[data-name='" + $(this).data("name") + "']").css("display", "none");
+        $(".js-viur-bones-str-language-wrapper[data-name='" + $(this).data("name") + "']").css("display", "none");
         var selector = "[data-name='" + $(this).data("name") + "'][data-lang='" + $(this).val() + "']";
-        $(".js_viur_bones_str_languageWrapper" + selector).css("display", "");
+        $(".js-viur-bones-str-language-wrapper" + selector).css("display", "");
     }).change();
 
 
-    $(".js_viur_bones_str_addSingleStrWrapper").click(function (evt) {
-        // create a new js_viur_bones_str_singleStrWrapper object and append it to the dom
-        var wrapDataObj = $(this).parents(".js_viur_bones_str_languageWrapper").first();
+    $(".js-viur-bones-str-add-single-str-wrapper").click(function (evt) {
+        // create a new js-viur-bones-str-single-str-wrapper object and append it to the dom
+        var wrapDataObj = $(this).parents(".js-viur-bones-str-language-wrapper").first();
         var boneName = "";
         if (wrapDataObj.length) {
             // We are multiple=True and have translations
             boneName = wrapDataObj.data("name") + '.' + wrapDataObj.data("lang");
         } else {
             // It's a multiple=True bone *without* translations
-            wrapDataObj = $(this).parents(".js_viur_bones_str_multiStrWrapper");
+            wrapDataObj = $(this).parents(".js-viur-bones-str-multi-str-wrapper");
             boneName = wrapDataObj.data("name");
         }
         var tpl = "";
-        tpl += '<div class="js_viur_bones_str_singleStrWrapper">';
-        tpl += '<input class="input js_viur_bones_str_translatedSingle" type="text"';
+        tpl += '<div class="js-viur-bones-str-single-str-wrapper">';
+        tpl += '<input class="input js-viur-bones-str-translated-single" type="text"';
         tpl += 'name="' + boneName + '"';
         tpl += 'value="">';
-        tpl += '<button class="button js_viur_bones_str_delteSingleStrWrapper">Delete</button>';
+        tpl += '<button class="button js-viur-bones-str-delte-single-str-wrapper">Delete</button>';
         tpl += '</div>';
         var singleStrWrapper = $(tpl);
         singleStrWrapper.insertBefore($(this));
-        viurBonesStrRebindDeleteStrButton(singleStrWrapper.find(".js_viur_bones_str_delteSingleStrWrapper"));
+        viurBonesStrRebindDeleteStrButton(singleStrWrapper.find(".js-viur-bones-str-delte-single-str-wrapper"));
         evt.preventDefault();
         return false;
-
     });
 
     // ---- Str Bones ----
 
-    $(".js_viur_bones_text_languageSelector").change(function () {
+    $(".js-viur-bones-text-language-selector").change(function () {
         // Show the corresponding text field
-        $(".js_viur_bones_text_languageWrapper[data-name='" + $(this).data("name") + "']").css("display", "none");
+        $(".js-viur-bones-text-language-wrapper[data-name='" + $(this).data("name") + "']").css("display", "none");
         var selector = "[data-name='" + $(this).data("name") + "'][data-lang='" + $(this).val() + "']";
-        $(".js_viur_bones_text_languageWrapper" + selector).css("display", "");
+        $(".js-viur-bones-text-language-wrapper" + selector).css("display", "");
     }).change();
-
 });

--- a/template/editform_bone_bone.html
+++ b/template/editform_bone_bone.html
@@ -1,1 +1,11 @@
-<input name="{{ boneName }}" value="{{ boneValue or "" }}">
+<input
+		class="switch-input ignt-input--boolean ignt-input--{{ boneName }}
+			{{ "is-required" if boneParams.required }}
+			{{ "is-readonly" if boneParams.readOnly }}
+			{{ "is-invalid" if boneWasInvalid else "is-valid" }}"
+		name="{{ boneName }}"
+		value="{{ boneValue or "" }}"
+		{{ "required" if boneParams.required }}
+		{{ "readonly" if boneParams.readOnly }}
+		{% if boneWasInvalid %} aria-invalid="true" {% endif %}
+>

--- a/template/editform_bone_bool.html
+++ b/template/editform_bone_bool.html
@@ -1,12 +1,17 @@
-<div class="switch">
-    <input class="switch-input ignt-booleanInput ignt-booleanInput-v{{ boneName }}"
-           id="ignt-id-{{ boneName }}"
-           type="checkbox"
-           name="{{ boneName }}"
-           value="true"
-           {{ "checked" if boneValue }}
-           {{ "required" if boneParams["required"] }}
-           {{ "readonly" if boneParams["readOnly"] }}
-    />
-    <label class="switch-label" for="ignt-id-{{ boneName }}"></label>
+<div class="switch ignt-switch">
+	<input
+			class="switch-input ignt-input--boolean ignt-input--{{ boneName }}
+				{{ "is-required" if boneParams.required }}
+				{{ "is-readonly" if boneParams.readOnly }}
+			{{ "is-invalid" if boneWasInvalid else "is-valid" }}"
+			id="ignt-id-{{ boneName }}"
+			type="checkbox"
+			name="{{ boneName }}"
+			value="true"
+			{{ "checked" if boneValue }}
+			{{ "required" if boneParams.required }}
+			{{ "readonly" if boneParams.readOnly }}
+			{% if boneWasInvalid %} aria-invalid="true" {% endif %}
+	>
+	<label class="switch-label" for="ignt-id-{{ boneName }}"></label>
 </div>

--- a/template/editform_bone_captcha.html
+++ b/template/editform_bone_captcha.html
@@ -1,6 +1,4 @@
 <div class="hidden2formfield">
-    <script src='https://www.google.com/recaptcha/api.js'></script>
+    <script src="https://www.google.com/recaptcha/api.js"></script>
     <div class="g-recaptcha" data-sitekey="{{ boneValue }}"></div>
 </div>
-
-

--- a/template/editform_bone_color.html
+++ b/template/editform_bone_color.html
@@ -1,12 +1,14 @@
-<input name="{{ boneName }}"
-        type="color"
-        title="{{ _(boneParams["tooltip"] or boneParams["descr"] or boneName) }}"
-        id="ignt-id-{{boneName}}"
-        value="{{ boneValue|default("",true) }}"
-        class="input ignt-colorInput ignt-colorInput-v{{ boneName }}
-             {{ "is-required" if boneParams.required }}
-            {{ "is-readonly" if boneParams.readOnly }}"
-        {{ "readonly" if boneParams.readOnly }}
-        {{ "required" if boneParams.required }}
-        {% if boneWasInvalid %} aria-invalid="true" {% endif %}
-/>
+<input
+		class="input ignt-input ignt-input--color ignt-input--{{ boneName }}
+			{{ "is-required" if boneParams.required }}
+			{{ "is-readonly" if boneParams.readOnly }}
+			{{ "is-invalid" if boneWasInvalid else "is-valid" }}"
+		name="{{ boneName }}"
+		type="color"
+		title="{{ _(boneParams.tooltip or boneParams.descr or boneName) }}"
+		id="ignt-id-{{ boneName }}"
+		value="{{ boneValue|default("", true) }}"
+		{{ "readonly" if boneParams.readOnly }}
+		{{ "required" if boneParams.required }}
+		{% if boneWasInvalid %} aria-invalid="true" {% endif %}
+>

--- a/template/editform_bone_date.html
+++ b/template/editform_bone_date.html
@@ -1,19 +1,21 @@
-<div id="ignt-id-{{ boneName }}" class="inputGroup">
-    {% if boneParams.date and boneParams.time %}
-        {# Current Webbrowsers dont support a datetime input yet so we'll split it up until they do #}
-        <input type="date" class="input" value="{% if boneValue %}{{ boneValue.strftime("%Y-%m-%d") }}{% endif %}"
-               name="{{ boneName }}-date" {% if boneParams.readOnly %}disabled="disabled"{% endif %}>
-        <input type="time" class="input" value="{% if boneValue %}{{ boneValue.strftime("%H:%M:%S") }}{% endif %}"
-               name="{{ boneName }}-time" {% if boneParams.readOnly %}disabled="disabled"{% endif %}>
-        <input type="hidden" value="{% if boneValue %}{{ boneValue.strftime("%Y-%M-%d") }}{% endif %}"
-               name="{{ boneName }}" class="js_viur_bones_date_doubleinput">
-    {% elif boneParams.date %}
-        <input type="date" class="input" value="{% if boneValue %}{{ boneValue.strftime("%Y-%m-%d") }}{% endif %}"
-               name="{{ boneName }}" {% if boneParams.readOnly %}disabled="disabled"{% endif %}>
-    {% elif boneParams.time %}
-        <input type="date" class="input" value="{% if boneValue %}{{ boneValue.strftime("%Y-%m-%d") }}{% endif %}"
-               name="{{ boneName }}" {% if boneParams.readOnly %}disabled="disabled"{% endif %}>
-    {% else %}
-        <!-- You messed up this datebone somehow -->
-    {% endif %}
+<div
+	id="ignt-id-{{ boneName }}"
+	class="input-group">
+	{% if boneParams.date and boneParams.time %}
+		{# Current Webbrowsers dont support a datetime input yet so we'll split it up until they do #}
+		<input type="date" class="input ignt-input ignt-input--date" value="{% if boneValue %}{{ boneValue.strftime("%Y-%m-%d") }}{% endif %}"
+			   name="{{ boneName }}-date" {% if boneParams.readOnly %}disabled="disabled"{% endif %}>
+		<input type="time" class="input ignt-input ignt-input--time" value="{% if boneValue %}{{ boneValue.strftime("%H:%M:%S") }}{% endif %}"
+			   name="{{ boneName }}-time" {% if boneParams.readOnly %}disabled="disabled"{% endif %}>
+		<input type="hidden" value="{% if boneValue %}{{ boneValue.strftime("%Y-%M-%d") }}{% endif %}"
+			   name="{{ boneName }}" class="js-viur-bones-date-doubleinput">
+	{% elif boneParams.date %}
+		<input type="date" class="input ignt-input ignt-input--date" value="{% if boneValue %}{{ boneValue.strftime("%Y-%m-%d") }}{% endif %}"
+			   name="{{ boneName }}" {% if boneParams.readOnly %}disabled="disabled"{% endif %}>
+	{% elif boneParams.time %}
+		<input type="time" class="input ignt-input ignt-input--time" value="{% if boneValue %}{{ boneValue.strftime("%H:%M:%S") }}{% endif %}"
+			   name="{{ boneName }}-time" {% if boneParams.readOnly %}disabled="disabled"{% endif %}>
+	{% else %}
+		<!-- You messed up this datebone somehow -->
+	{% endif %}
 </div>

--- a/template/editform_bone_numeric.html
+++ b/template/editform_bone_numeric.html
@@ -1,25 +1,28 @@
-{% if boneParams.precision<0 %}
+{%- if boneParams.precision < 0 -%}
     {# if precision is < 0, we only allow powers of 10 to be selected by forcing the last n digits to be allways
     zero (ie. ..., 0, 10, 20, ... or ..., 0, 100, 200, ...). We ensure that the last digits of our min/max value
     matches that alley by foring the last n digits to be 0. Otherwise we  might end up in shifted alleys
     ( ..., -4, 6, 16, ... or the like) #}
-    {% set min = (boneParams.min|string)[:-(boneParams.precision|abs)]+"0"*(boneParams.precision|abs) %}
-    {% set max = (boneParams.max|string)[:-(boneParams.precision|abs)]+"0"*(boneParams.precision|abs) %}
-{% else %}
-    {% set min = boneParams.min %}
-    {% set max = boneParams.max %}
-{% endif %}
+    {%- set min = (boneParams.min|string)[:-(boneParams.precision|abs)]+"0"*(boneParams.precision|abs) -%}
+    {%- set max = (boneParams.max|string)[:-(boneParams.precision|abs)]+"0"*(boneParams.precision|abs) -%}
+{%- else -%}
+    {% set min = boneParams.min -%}
+    {% set max = boneParams.max -%}
+{%- endif -%}
 
-<input name="{{ boneName }}"
-        type="number"
-        title="{{ _(boneParams["tooltip"] or boneParams["descr"] or boneName) }}"
-        id="ignt-id-{{boneName}}"
-        value="{{ boneValue|default("",true) }}"
-        class="input ignt-numericInput ignt-numericInput-v{{ boneName }}
-             {{ ' is-required ' if boneParams.required }} {{ ' is-readonly ' if boneParams.readOnly }}"
+<input
+		class="input ignt-input ignt-input-numeric ignt-input--{{ boneName }}
+			{{ "is-required" if boneParams.required }}
+			{{ "is-readonly" if boneParams.readOnly }}
+			{{ "is-invalid" if boneWasInvalid else "is-valid" }}"
+		value="{{ boneValue|default("", true) }}"
+		name="{{ boneName }}"
+		type="number"
+		title="{{ _(boneParams.tooltip or boneParams.descr or boneName) }}"
+		id="ignt-id-{{boneName}}"
         {% if min %} min="{{ min }}" {% endif %}
         {% if max %} max="{{ max }}" {% endif %}
         {{ "readonly" if boneParams.readOnly }}
         {{ "required" if boneParams.required }}
         {% if boneWasInvalid %} aria-invalid="true" {% endif %}
-/>
+>

--- a/template/editform_bone_password.html
+++ b/template/editform_bone_password.html
@@ -1,14 +1,14 @@
 <input
-    name="{{ boneName }}"
-    type="password"
-    title="{{ _(boneParams["tooltip"] or boneParams["descr"] or boneName) }}"
-    class="input ignt-passwordInput ignt-passwordInput-v{{ boneName }}
-        {{ ' is-required ' if boneParams.required }} {{ ' is-readonly ' if boneParams.readOnly }}"
-    id="ignt-id-{{ boneName }}"
-    value="{{ boneValue|default("", true) }}"
-    {% if boneWasInvalid %}
-        aria-invalid="true"
-    {% endif %}
-    {{ "required" if boneParams.required }}
-    {{ "readonly" if boneParams.readOnly }}
-/>
+		class="input ignt-input ignt-input--password ignt-ignt--{{ boneName }}
+			{{ "is-required" if boneParams.required }}
+			{{ "is-readonly" if boneParams.readOnly }}
+			{{ "is-invalid" if boneWasInvalid else "is-valid" }}"
+		name="{{ boneName }}"
+		type="password"
+		title="{{ _(boneParams.tooltip or boneParams.descr or boneName) }}"
+		id="ignt-id-{{ boneName }}"
+		value="{{ boneValue|default("", true) }}"
+		{{ "required" if boneParams.required }}
+		{{ "readonly" if boneParams.readOnly }}
+		{% if boneWasInvalid %} aria-invalid="true" {% endif %}
+>

--- a/template/editform_bone_relational.treeitem.file.html
+++ b/template/editform_bone_relational.treeitem.file.html
@@ -1,18 +1,18 @@
 {% if not boneParams.multiple %}
     {# Single #}
-    <div class="vi-file inputGroup inputGroupFile {% if not boneParams.readOnly %}js_viur_bones_file_uploadableInputGroup{% endif %} {% if not boneValue %}isEmpty{% endif %}"
+    <div class="vi-file input-group input-group-file {% if not boneParams.readOnly %}js-viur-bones-file_uploadableinput-group{% endif %} {% if not boneValue %}is-empty{% endif %}"
          data-name="{{ boneName }}"
          data-multiple="0">
-        <div class="vi-fileBone-previewImg"
+        <div class="vi-file-bone-preview-img"
              {% if boneValue and boneValue.servingurl %}style="background-image: url({{ boneValue.servingurl }}=s150)"{% endif %}>
         </div>
         <span class="input{% if boneParams.readOnly %} is-readonly{% endif %}">{% if boneValue %}
             {{ boneValue.name }}{% endif %}</span>
         {% if not boneParams.readOnly %}
-            <button class="btn icon edit js_viur_bones_file_uploadFileButton" type="button" data-name="{{ boneName }}">
+            <button class="btn icon edit js-viur-bones-file-upload-file-button" type="button" data-name="{{ boneName }}">
                 Upload
             </button>
-            <button class="btn icon cancel btn-vDanger js_viur_bones_file_removeFile" type="button">Entfernen</button>
+            <button class="btn icon cancel btn--danger js-viur-bones-file-remove-file" type="button">Entfernen</button>
             <span class="uploader" style="width: 300px; height: 50px;"></span>
         {% endif %}
         <input type="hidden" name="{{ boneName }}.0.key" value="{% if boneValue %}{{ boneValue.key }}{% endif %}">
@@ -20,21 +20,21 @@
     </div>
 {% else %}
     {# Multiple #}
-    <div class="vi-boneEditor can-upload" id="vi_0_db_produkt_edit_Allgemein_bn_images">
-        <div class="vi-selection js_viur_bones_file_reordableArea" data-name="{{ boneName }}">
+    <div class="vi-bone-editor can-upload" id="">
+        <div class="vi-selection js-viur-bones-file-reordable-area" data-name="{{ boneName }}">
             {% if boneValue %}
                 {% for value in boneValue %}
-                    <div class="vi-file inputGroup inputGroupFile js_viur_bones_file_reordableItem" data-multiple="1"
+                    <div class="vi-file input-group input-group-file js-viur-bones-file-reordable-item" data-multiple="1"
                          {% if not boneParams.readOnly %}draggable="true"{% endif %}>
-                        <div class="vi-fileMultiBone-previewImg"
+                        <div class="vi-file-multi-bone-preview-img"
                              {% if value.servingurl %}style="background-image: url({{ value.servingurl }}=s150)"{% endif %}>
                         </div>
                         <span class="input {% if boneParams.readOnly %}is-readonly{% endif %}">{{ value.name }}</span>
                         {% if not boneParams.readOnly %}
-                            <button class="btn icon edit is-disabled js_viur_bones_file_uploadFileButton" type="button">
+                            <button class="btn icon edit is-disabled js-viur-bones-file-upload-file-button" type="button">
                                 Bearbeiten
                             </button>
-                            <button class="btn icon cancel btn-vDanger is-disabled js_viur_bones_file_removeFile"
+                            <button class="btn icon cancel btn--danger is-disabled js-viur-bones-file-remove-file"
                                     type="button">Entfernen
                             </button>
                             <span class="uploader" style="width: 300px; height: 50px;"></span>
@@ -45,15 +45,16 @@
             {% endif %}
         </div>
         {% if not boneParams.readOnly %}
-            <button class="btn icon edit js_viur_bones_file_addFiles" type="button">
+            <button class="btn icon edit js-viur-bones-file-add-files" type="button">
             Hinzufügen
         {% endif %}
         </button>
 
     </div>
 {% endif %}
-<style type="text/css">
-    .vi-fileMultiBone-previewImg, .vi-fileBone-previewImg {
+<style>
+    .vi-file-multi-bone-preview-img,
+	.vi-file-bone-preview-img {
         width: 100px;
         height: 100px;
         display: block;
@@ -71,13 +72,13 @@
         opacity: 0.2;
     }
 
-    .js_viur_bones_file_reordableArea {
+    .js-viur-bones-file-reordable-area {
         padding-bottom: 20px;
         padding-top: 20px;
         border: 1px solid red;
     }
 
-    .js_viur_bones_file_reordableItem {
+    .js-viur-bones-file-reordable-item {
         border: 1px solid green;
     }
 </style>

--- a/template/editform_bone_select.html
+++ b/template/editform_bone_select.html
@@ -1,6 +1,6 @@
 {% if boneParams.multiple %}
-    <div class="optionGroup">
-        {% for key, descr in boneParams["values"].items() %}
+    <div class="option-group">
+        {% for key, descr in boneParams.values.items() %}
             <div class="check">
                 <input
                     class="check-input"
@@ -9,7 +9,7 @@
                     value="{{ key }}"
                     type="checkbox"
                     {{ "checked" if key in boneValue }}
-                    {{ "readonly" if boneParams["readOnly"] }}>
+                    {{ "readonly" if boneParams.readOnly }}>
 
                 <label class="check-label" for="ignt-id-{{ boneName }}_{{ key }}">{{ descr }}</label>
             </div>
@@ -17,16 +17,16 @@
     </div>
 {% else %}
     <select
-    id="ignt-id-{{ boneName }}"
-    name="{{ boneName }}"
-    class="select ignt-select ignt-select-v{{ boneName }}
-        {{ "is-required" if boneParams.required }}
-        {{ "is-readonly" if boneParams.readOnly }}
-        {{ "is-invalid" if boneWasInvalid }}"
-    {{'readonly' if boneParams.readOnly}}
-    {{'required' if boneParams.required}}
+		id="ignt-id-{{ boneName }}"
+		name="{{ boneName }}"
+		class="select ignt-select ignt-select--{{ boneName }}
+			{{ "is-required" if boneParams.required }}
+			{{ "is-readonly" if boneParams.readOnly }}
+			{{ "is-invalid" if boneWasInvalid else "is-valid" }}"
+		{{'readonly' if boneParams.readOnly}}
+		{{'required' if boneParams.required}}
     >
-        {%- for key, descr in boneParams["values"].items() %}
+        {%- for key, descr in boneParams.values.items() %}
             {% if loop.first %}
                 <option value="" {{ "selected" if not boneValue }} {{ "disabled" if boneParams.required}} hidden>
                     -

--- a/template/editform_bone_str.html
+++ b/template/editform_bone_str.html
@@ -1,27 +1,27 @@
 {% if boneParams.multiple and boneParams.languages %}
-    <div class="vi-boneTranslator">
-        <div class="vi-boneEditor">
+    <div class="vi-bone-translator">
+        <div class="vi-bone-editor">
             {% for lang in boneParams.languages %}
-                <div class="vi-languageWrapper js_viur_bones_str_languageWrapper" data-name="{{ boneName }}"
+                <div class="vi-languageWrapper js-viur-bones-str-language-wrapper" data-name="{{ boneName }}"
                      data-lang="{{ lang }}">
-                    <div class="js_viur_bones_str_multiStrWrapper">
+                    <div class="js-viur-bones-str-multi-str-wrapper">
                         {% if boneValue %}
                             {% for val in boneValue.get(lang, []) %}
-                                <div class="js_viur_bones_str_singleStrWrapper">
-                                    <input class="input js_viur_bones_str_translatedSingle" type="text"
+                                <div class="js-viur-bones-str-single-str-wrapper">
+                                    <input class="input js-viur-bones-str-translated-single" type="text"
                                            name="{{ boneName }}.{{ lang }}"
                                            value="{{ val }}">
-                                    <button class="button js_viur_bones_str_delteSingleStrWrapper">Delete</button>
+                                    <button class="button js-viur-bones-str-delte-single-str-wrapper">Delete</button>
                                 </div>
                             {% endfor %}
                         {% endif %}
-                        <button class="button js_viur_bones_str_addSingleStrWrapper">Add</button>
+                        <button class="button js-viur-bones-str-add-single-str-wrapper">Add</button>
                     </div>
                 </div>
             {% endfor %}
-            <select class="select js_viur_bones_str_languageSelector" name="{{ boneName }}_language_selector"
+            <select class="select js-viur-bones-str-language-selector" name="{{ boneName }}_language_selector"
                     data-name="{{ boneName }}"
-                    id="vi_0_db_produkt_edit_Allgemein_bn_kauftenauch">
+                    id="">
                 {% for lang in boneParams.languages %}
                     <option value="{{ lang }}">{{ lang }}</option>
                 {% endfor %}
@@ -29,10 +29,10 @@
         </div>
     </div>
 {% elif not boneParams.multiple and boneParams.languages %}
-    <div class="vi-boneTranslator" id="vi_0_db_produkt_edit_Allgemein_bn_name">
-        <div class="vi-boneEditor">
+    <div class="vi-bone-translator" id="">
+        <div class="vi-bone-editor">
             {% for lang in boneParams.languages %}
-                <div class="vi-languageWrapper js_viur_bones_str_languageWrapper" data-name="{{ boneName }}"
+                <div class="vi-languageWrapper js-viur-bones-str-language-wrapper" data-name="{{ boneName }}"
                      data-lang="{{ lang }}">
                     <input class="input" type="text"
                            name="{{ boneName }}.{{ lang }}"
@@ -40,45 +40,45 @@
                 </div>
             {% endfor %}
         </div>
-        <select class="select js_viur_bones_str_languageSelector" name="{{ boneName }}_language_selector"
+        <select class="select js-viur-bones-str-language-selector" name="{{ boneName }}_language_selector"
                 data-name="{{ boneName }}"
-                id="vi_0_db_produkt_edit_Allgemein_bn_kauftenauch">
+                id="">
             {% for lang in boneParams.languages %}
                 <option value="{{ lang }}">{{ lang }}</option>
             {% endfor %}
         </select>
     </div>
 {% elif boneParams.multiple and not boneParams.languages %}
-    <div class="js_viur_bones_str_multiStrWrapper" data-name="{{ boneName }}">
+    <div class="js-viur-bones-str-multi-str-wrapper" data-name="{{ boneName }}">
         {% if boneValue %}
             {% for val in boneValue %}
-                <div class="js_viur_bones_str_singleStrWrapper">
-                    <input class="input js_viur_bones_str_translatedSingle" type="text"
+                <div class="js-viur-bones-str-single-str-wrapper">
+                    <input class="input js-viur-bones-str-translated-single" type="text"
                            name="{{ boneName }}"
                            value="{{ val }}">
-                    <button class="button js_viur_bones_str_delteSingleStrWrapper">Delete</button>
+                    <button class="button js-viur-bones-str-delte-single-str-wrapper">Delete</button>
                 </div>
             {% endfor %}
         {% endif %}
-        <button class="button js_viur_bones_str_addSingleStrWrapper">Add</button>
+        <button class="button js-viur-bones-str-add-single-str-wrapper">Add</button>
     </div>
 {% else %}
     <input
         name="{{ boneName }}"
-        type="{{ "email" if boneParams["type"] == "str.email" else "text" }}"
-        title="{{ _(boneParams["tooltip"] or boneParams["descr"] or boneName) }}"
-        placeholder="{{ _(boneParams["tooltip"] or boneParams["descr"] or boneName) }}"
-        class="input ignt-stringInput ignt-stringInput-v{{ boneName }}
-            {{ ' is-required ' if boneParams.required }} {{ ' is-readonly ' if boneParams.readOnly }}"
+        type="{{ "email" if boneParams.type == "str.email" else "text" }}"
+        title="{{ _(boneParams.tooltip or boneParams.descr or boneName) }}"
+        placeholder="{{ _(boneParams.tooltip or boneParams.descr or boneName) }}"
+        class="input ignt-input ignt-input--string ignt-input--{{ boneName }}
+            {{ "is-required" if boneParams.required }}
+			{{ "is-readonly" if boneParams.readOnly }}
+			{{ "is-invalid" if boneWasInvalid else "is-valid" }}"
         id="ignt-id-{{ boneName }}"
         value="{{ boneValue|default("", true) }}"
-        {% if boneParams["maxlength"] %}
-            maxlength="{{ boneParams["maxlength"]|int }}"
-        {% endif %}
-        {% if boneWasInvalid %}
-            aria-invalid="true"
+        {% if boneParams.maxlength %}
+            maxlength="{{ boneParams.maxlength|int }}"
         {% endif %}
         {{ "required" if boneParams.required }}
         {{ "readonly" if boneParams.readOnly }}
-    />
+		{% if boneWasInvalid %} aria-invalid="true" {% endif %}
+    >
 {% endif %}

--- a/template/editform_bone_text.html
+++ b/template/editform_bone_text.html
@@ -1,22 +1,18 @@
-{% set readOnly = "" %}
-{% if boneParams.readOnly %}
-    {% set readOnly = 'readonly="readonly"' %}
-{% endif %}
 {% if boneParams.languages %}
     {% for lang in boneParams.languages %}
-        <div class="vi-languageWrapper js_viur_bones_text_languageWrapper" data-name="{{ boneName }}"
+        <div class="vi-language-wrapper js-viur-bones-text-language-wrapper" data-name="{{ boneName }}"
              data-lang="{{ lang }}">
             <textarea class="textarea vi-textarea" name="{{ boneName }}.{{ lang }}">
                 {%- if boneValue -%}{{ boneValue.get(lang,"") }}{%- endif -%}
             </textarea>
-            <div class="textarea vi-textarea vi-textBone-preview" style="display: none">
+            <div class="textarea vi-textarea vi-text-bone-preview" style="display: none">
                 {% if boneValue %}{{ boneValue.get(lang,"") }}{% endif %}
             </div>
-            <button class="btn textedit icon btn-vEdit" type="button">Text bearbeiten</button>
+            <button class="btn textedit icon btn--edit" type="button">Text bearbeiten</button>
         </div>
     {% endfor %}
 
-    <select class="select js_viur_bones_text_languageSelector" name="{{ boneName }}_language_selector"
+    <select class="select js-viur-bones-text-language-selector" name="{{ boneName }}_language_selector"
             data-name="{{ boneName }}">
         {% for lang in boneParams.languages %}
             <option value="{{ lang }}">{{ lang }}</option>
@@ -25,12 +21,14 @@
 {% else %}
     <textarea
         name="{{ boneName }}"
-		class="textarea ignt-textarea ignt-textarea-v{{ boneName }}
-			    {{ 'is-required' if boneParams.required }}
-                {{ 'is-readonly' if boneParams.readOnly }}"
-			  id="ignt-id-{{ boneName }}"
-        {{ "readonly" if boneParams.readOnly}}
-        {{ "required" if boneParams.required}}>
+		class="textarea ignt-textarea ignt-textarea--{{ boneName }}
+				{{ "is-required" if boneParams.required }}
+				{{ "is-readonly" if boneParams.readOnly }}
+				{{ "is-invalid" if boneWasInvalid else "is-valid" }}"
+		id="ignt-id-{{ boneName }}"
+        {{ "readonly" if boneParams.readOnly }}
+        {{ "required" if boneParams.required }}
+	>
 		{{- boneValue|default("",true) -}}
 	</textarea>
 {% endif %}

--- a/template/editform_category.html
+++ b/template/editform_category.html
@@ -1,3 +1,5 @@
-<fieldset class="formGroup ignt-category" name="{{ categoryName }}">
-    {{ categoryContent }}
+<fieldset
+		class="form-group ignt-category"
+		name="{{ categoryName }}">
+    	{{ categoryContent }}
 </fieldset>

--- a/template/editform_row.html
+++ b/template/editform_row.html
@@ -1,14 +1,16 @@
 {% if boneParams.visible %}
-    <div class="inputGroup ignt-bone">
-        <label
-            class="label ignt-label
-            {{ "is-required" if boneParams.required }}
-            {{ "is-invalid" if boneWasInvalid }}">
+	<div class="input-group ignt-bone">
+		<label
+			class="label ignt-label
+				{{ "is-required" if boneParams.required }}
+				{{ "is-readonly" if boneParams.readOnly }}
+				{{ "is-invalid" if boneWasInvalid else "is-valid" }}"
+		>
 			{{ boneParams.descr }}
 		</label>
 
-        {{ editWidget }}
-    </div>
+		{{ editWidget }}
+	</div>
 {% else %}
-    {{ editWidget }}
+	{{ editWidget }}
 {% endif %}

--- a/template/error.html
+++ b/template/error.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta charset="UTF-8">
     <title>$error_code - $error_name</title>
-    <link rel="stylesheet" type="text/css" media="screen" href="/resources/css/error/error.css" />
+    <link rel="stylesheet" href="/resources/css/error/error.css">
 </head>
 
 <body>
@@ -12,20 +12,21 @@
             <div id="content">
 
                 <h1>$error_code</h1>
-                
-                <a class="logo" href="http://www.viur.is">&nbsp;</a>
+
+                <a class="logo" href="https://www.viur.is">&nbsp;</a>
 
                 <div class="clear">&nbsp;</div>
 
                 <h2>$error_name</h2>
 
                 <p>$error_descr</p>
-		
-		<div class="wrapper-buttons">
+
+				<div class="wrapper-buttons">
                     <a href="/" class="button-red shadow">Home</a>
                     <div class="clear">&nbsp;</div>
                 </div>
             </div>
         </div>
     </div>
+</body>
 </html>


### PR DESCRIPTION
Improved (ignite) templates to provide a consistent syntax.
- Changed syntax of css classes, we don't want to use camelcase for css classes anymore. `.inputGroup` --> `.input-group`
- make sure, that every template contains the same attributes (like `required`) if necessary
- made errorpage html5-compliant and added missing `</body>` tag