### PR TITLE
Fix date bone visible if magic

### DIFF
--- a/bones/dateBone.py
+++ b/bones/dateBone.py
@@ -72,7 +72,6 @@ class dateBone( baseBone ):
 		baseBone.__init__( self,  *args,  **kwargs )
 		if creationMagic or updateMagic:
 			self.readonly = True
-			self.visible = False
 		self.creationMagic = creationMagic
 		self.updateMagic = updateMagic
 		if not( date or time ):


### PR DESCRIPTION
Hi there,
why do creationMagic=True or updateMagic=True bones are enforced to be visible=False?
It should be freedom of the developer to decide whether a bone is visible or not...