### PR TITLE
dimensions in refKeys and refresh task

### DIFF
--- a/bones/fileBone.py
+++ b/bones/fileBone.py
@@ -9,7 +9,7 @@ import logging
 class fileBone(treeItemBone):
 	kind = "file"
 	type = "relational.treeitem.file"
-	refKeys = ["name", "key", "meta_mime", "metamime", "mimetype", "dlkey", "servingurl", "size"]
+	refKeys = ["name", "key", "meta_mime", "metamime", "mimetype", "dlkey", "servingurl", "size", "width", "height"]
 
 	def __init__(self, format="$(dest.name)",*args, **kwargs ):
 		assert "dlkey" in self.refKeys, "You cannot remove dlkey from refKeys!"

--- a/modules/file.py
+++ b/modules/file.py
@@ -29,8 +29,8 @@ class fileBaseSkel(TreeLeafSkel):
 	mimetype = stringBone(descr="Mime-Info", readOnly=True, indexed=True )
 	weak = booleanBone(descr="Weak reference", indexed=True, readOnly=True, visible=False)
 	servingurl = stringBone(descr="Serving URL", readOnly=True)
-	width = numericBone(descr="Width", indexed=True, searchable=True)
-	height = numericBone(descr="Height", indexed=True, searchable=True)
+	width = numericBone(descr="Width", indexed=True, readOnly=True, searchable=True)
+	height = numericBone(descr="Height", indexed=True, readOnly=True, searchable=True)
 
 	def refresh(self):
 		# Update from blobimportmap
@@ -49,16 +49,6 @@ class fileBaseSkel(TreeLeafSkel):
 					self["servingurl"] = images.get_serving_url(self["dlkey"])
 				except Exception as e:
 					logging.exception(e)
-
-		try:
-			# only fetching the file header or all if the file is smaller than 1M
-			data = blobstore.fetch_data(self["dlkey"], 0, min(self["size"], 1000000))
-			image = images.Image(image_data=data)
-			self["height"] = image.height
-			self["width"] = image.width
-		except Exception as err:
-			logging.error("some error occurred while trying to fetch the image header with dimensions")
-			logging.exception(err)
 
 		super(fileBaseSkel, self).refresh()
 

--- a/modules/file.py
+++ b/modules/file.py
@@ -49,6 +49,17 @@ class fileBaseSkel(TreeLeafSkel):
 					self["servingurl"] = images.get_serving_url(self["dlkey"])
 				except Exception as e:
 					logging.exception(e)
+
+		try:
+			# only fetching the file header or all if the file is smaller than 1M
+			data = blobstore.fetch_data(self["dlkey"], 0, min(self["size"], 1000000))
+			image = images.Image(image_data=data)
+			self["height"] = image.height
+			self["width"] = image.width
+		except Exception as err:
+			logging.error("some error occurred while trying to fetch the image header with dimensions")
+			logging.exception(err)
+
 		super(fileBaseSkel, self).refresh()
 
 	def preProcessBlobLocks(self, locks):


### PR DESCRIPTION
It would be nice and sometimes necessary to get the dimensions of an image.
So I added width and height to refkeys of fileBone and update the dimensions on refresh from blobstore.