### PR TITLE
fixed emailRecipientOverride in sendMail

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -54,41 +54,24 @@ def sendEMail(dests, name, skel, extraFiles=[], cc=None, bcc=None, replyTo=None,
 	:type replyTo: str
 	:param replyTo: A reply-to email address
 	"""
-
-	def rewriteEmail(oldDests, newDest):
-		"""
-			Rewrites each address in *oldDests* so that it will end with @newDest
-			:param oldDests: EMail-Address (or a list hereof) to rewrite
-			:type oldDests: str | list[str]
-			:param newDest: New Destination-Domain (eg "@mausbrand.de")
-			:type newDest: str
-			:return:
-		"""
-		if isinstance( oldDests, list ):
-			return [rewriteEmail(x, newDest) for x in oldDests ]
-		else:
-			newAddress = oldDests.replace(".", "_dot_").replace("@", "_at_")
-			return "%s%s" % (newAddress, newDest)
-
 	if conf["viur.emailRecipientOverride"]:
 		logging.warning("Overriding destination %s with %s", dests, conf["viur.emailRecipientOverride"])
 
-		if isinstance(conf["viur.emailRecipientOverride"], list):
-			tmpDests = []
-			for newRecipient in conf["viur.emailRecipientOverride"]:
-				if newRecipient.startswith("@"):
-					# use extend here, because rewriteEmail returns a list if we have multiple oldDests
-					tmpDests.extend(rewriteEmail(dests, newRecipient))
-				else:
-					tmpDests.append(newRecipient)
-			dests = tmpDests
+		oldDests = dests
+		if isinstance(oldDests, basestring):
+			oldDests = [oldDests]
 
-		elif isinstance(conf["viur.emailRecipientOverride"], basestring):
-			if conf["viur.emailRecipientOverride"].startswith("@"):
-				dests = rewriteEmail(dests, conf["viur.emailRecipientOverride"])
+		newDests = conf["viur.emailRecipientOverride"]
+		if isinstance(newDests, basestring):
+			newDests = [newDests]
 
-		else:
-			dests = conf["viur.emailRecipientOverride"]
+		dests = []
+		for newDest in newDests:
+			if newDest.startswith("@"):
+				for oldDest in oldDests:
+					dests.append(oldDest.replace(".", "_dot_").replace("@", "_at_") + newDest)
+			else:
+				dests.append(newDest)
 
 	elif conf["viur.emailRecipientOverride"] is False:
 		logging.warning("Sending emails disabled by config[viur.emailRecipientOverride]")

--- a/utils.py
+++ b/utils.py
@@ -83,7 +83,7 @@ def sendEMail(dests, name, skel, extraFiles=[], cc=None, bcc=None, replyTo=None,
 					tmpDests.append(newRecipient)
 			dests = tmpDests
 
-		elif isinstance(conf["viur.emailRecipientOverride"], str):
+		elif isinstance(conf["viur.emailRecipientOverride"], basestring):
 			if conf["viur.emailRecipientOverride"].startswith("@"):
 				dests = rewriteEmail(dests, conf["viur.emailRecipientOverride"])
 


### PR DESCRIPTION
When you overwrite the dest with a list of receipients, e.g.: 
```python
conf["viur.emailRecipientOverride"] = ["se@mausbrand.de"]
```
the old line 75:
```python
if conf["viur.emailRecipientOverride"].startswith("@"):
```
applies `.startswith()` on a list which will cause an error.


While fixing this I found an other mistake on the recursive call in for of rewriteEmail in line 68:
```python
return [rewriteEmail(x) for x in oldDests ]
```
rewriteEmail expects two argmuments, but got only one.
