### PR TITLE
Allow empty date setting to dateBone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This file documents any relevant changes done to ViUR server since version 2.
 - Allow in-tests in values of selectBone ([#139](https://github.com/viur-framework/server/pull/139))
 - The dbtransfer/upload to correctly obtain the oldBlobKey ([#103](https://github.com/viur-framework/server/pull/103))
 - Improved handling of email-recipient-override in utils.sendMail ([#136](https://github.com/viur-framework/server/pull/136))
+- Allow setting a dateBone back to None again ([#155](https://github.com/viur-framework/server/pull/155))
 
 ### Removed
 - pytz. It's now provided in the base repo 

--- a/bones/dateBone.py
+++ b/bones/dateBone.py
@@ -99,7 +99,7 @@ class dateBone( baseBone ):
 		"""
 		rawValue = data.get(name, None)
 		if not rawValue:
-			value = None
+			value = rawValue
 		elif unicode(rawValue).replace("-",  "",  1).replace(".","",1).isdigit():
 			if int(rawValue) < -1*(2**30) or int(rawValue)>(2**31)-2:
 				value = False  # its invalid
@@ -158,7 +158,7 @@ class dateBone( baseBone ):
 		else:
 			err = self.isInvalid(value)
 			if not err:
-				valuesCache[name] = value
+				valuesCache[name] = value if value else None
 				if value is None:
 					return "No value entered"
 			return err

--- a/bones/dateBone.py
+++ b/bones/dateBone.py
@@ -99,7 +99,7 @@ class dateBone( baseBone ):
 		"""
 		rawValue = data.get(name, None)
 		if not rawValue:
-			value = rawValue
+			value = None
 		elif unicode(rawValue).replace("-",  "",  1).replace(".","",1).isdigit():
 			if int(rawValue) < -1*(2**30) or int(rawValue)>(2**31)-2:
 				value = False  # its invalid
@@ -157,8 +157,8 @@ class dateBone( baseBone ):
 			return "Invalid value entered"
 		else:
 			err = self.isInvalid(value)
-			if not err:
-				valuesCache[name] = value if value else None
+			if not err or value is None:
+				valuesCache[name] = value
 				if value is None:
 					return "No value entered"
 			return err


### PR DESCRIPTION
Setting a date back to empty is not possible using fromClient right now: Empty string is converted to None, and None is not allowed by super-call to baseBone.isInvalid() as valid value. So this might fix the problem and integrates with [#32](https://github.com/viur-framework/vi/pull/32) in vi.