### PR TITLE
removing old .value notation for bone value access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This file documents any relevant changes done to ViUR server since version 2.
 - Dimensions (height and width) of an image are now provided by the refKeys of a fileBone ([#134](https://github.com/viur-framework/server/pull/134))
 
 ### Fixed
+- Invalid bone access in periodic tasks of modules/order.py ([#157](https://github.com/viur-framework/server/pull/157))
 - Signature of serialize() in randomSliceBone ([#98](https://github.com/viur-framework/server/pull/98))
 - Search for templates in the correct path if the htmlpath has been overridden by the class variable. ([#108](https://github.com/viur-framework/server/pull/108))
 - Several typos, readability and incorrect docstrings ([#109](https://github.com/viur-framework/server/pull/109) [#140](https://github.com/viur-framework/server/pull/140) [#143](https://github.com/viur-framework/server/pull/143))

--- a/modules/order.py
+++ b/modules/order.py
@@ -867,7 +867,7 @@ class Order( List ):
 
 		for order in query.fetch():
 			gotAtLeastOne = True
-			self.setArchived(order["key"].value)
+			self.setArchived(order["key"])
 
 		newCursor = query.getCursor()
 
@@ -887,7 +887,7 @@ class Order( List ):
 
 		for order in query.fetch():
 			gotAtLeastOne = True
-			self.setArchived(order["key"].value)
+			self.setArchived(order["key"])
 
 		newCursor = query.getCursor()
 


### PR DESCRIPTION
This patch removes two regressions when cleaning up old and/or unfinished order entries