### PR TITLE
Suitable bugfix for #48

### DIFF
--- a/modules/user.py
+++ b/modules/user.py
@@ -663,7 +663,10 @@ class User(List):
 
 	@exposed
 	def login(self, *args, **kwargs):
-		self.render.login(self.validAuthenticationMethods)
+		authMethods = [(x.getAuthMethodName(), y.get2FactorMethodName() if y else None)
+					   	for x, y in self.validAuthenticationMethods]
+
+		return self.render.login(authMethods)
 
 	def onLogin(self):
 		usr = self.getCurrentUser()

--- a/render/html/user.py
+++ b/render/html/user.py
@@ -12,8 +12,14 @@ class Render( default.Render ): #Render user-data to xml
 	verifyFailedTemplate = "user_verify_failed"
 	passwdRecoverInfoTemplate = "user_passwdrecover_info"
 
-	def login( self, skel, tpl=None,  **kwargs ):
-		return( self.edit( skel,  tpl=(tpl or self.loginTemplate), **kwargs ) )
+	def login(self, authMethods, tpl=None,  **kwargs):
+		if "loginTemplate" in dir(self.parent):
+			tpl = tpl or self.parent.loginTemplate
+		else:
+			tpl = tpl or self.loginTemplate
+
+		template = self.getEnv().get_template(self.getTemplateFileName(tpl))
+		return template.render(authMethods=authMethods, **kwargs)
 
 	def loginSucceeded( self, tpl=None, **kwargs ):
 		if "loginSuccessTemplate" in dir( self.parent ):


### PR DESCRIPTION
This is a bugfix for #48

The following Jinja template user_login.html could handle this:

```jinja2
<html>
    <ul>
        {% for method in authMethods %}
            {% set method = method[0]|replace("X-VIUR-AUTH-", "")|replace("X-AUTH-", "")|replace("-", "")|lower %}
            <li><a href="/user/auth_{{ method }}/login">{{ method }}</a></li>
        {% endfor %}
    </ul>
</html>
```