### PR TITLE
changed behavior of non-image files in upload method of file module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This file documents any relevant changes done to ViUR server since version 2.
 - Stability improvements on several bones ([#125](https://github.com/viur-framework/server/pull/125))
 - Log exception with traceback if loading or parsing of email templates fail ([#127](https://github.com/viur-framework/server/pull/127))
 - Dimensions (height and width) of an image are now provided by the refKeys of a fileBone ([#134](https://github.com/viur-framework/server/pull/134))
+- Dimensions will only fetch from blobstore if an image was uploaded. ([#161](https://github.com/viur-framework/server/pull/161))
 
 ### Fixed
 - Invalid bone access in periodic tasks of modules/order.py ([#157](https://github.com/viur-framework/server/pull/157))


### PR DESCRIPTION
After I upload a file, which is not an image I get usually this error in the log. It's annoying.

```
ERROR    2019-05-06 15:46:59,679 file.py:262] some error occurred while trying to fetch the image header with dimensions
ERROR    2019-05-06 15:46:59,679 file.py:263] Unrecognized image format
Traceback (most recent call last):
  File "/.../server/modules/file.py", line 257, in upload
    height = image.height
  File "/.../bin/google-cloud-sdk/platform/google_appengine/google/appengine/api/images/__init__.py", line 933, in height
    self._update_dimensions()
  File "/.../bin/google-cloud-sdk/platform/google_appengine/google/appengine/api/images/__init__.py", line 285, in _update_dimensions
    raise NotImageError("Unrecognized image format")
NotImageError: Unrecognized image format
```

I moved the corresponding part in the already existing "file-is-image"-part. And refactored the code a little bit.