### PR TITLE
Entries fetched with db.GetOrInsert and written with db.Put will now correctly flush the memcache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This file documents any relevant changes done to ViUR server since version 2.
 - Dimensions will only fetch from blobstore if an image was uploaded. ([#161](https://github.com/viur-framework/server/pull/161))
 
 ### Fixed
+- *[Severe]* Entries fetched with db.GetOrInsert and written with db.Put will now correctly flush the memcache ([#162](https://github.com/viur-framework/server/pull/162))
 - Invalid bone access in periodic tasks of modules/order.py ([#157](https://github.com/viur-framework/server/pull/157))
 - Signature of serialize() in randomSliceBone ([#98](https://github.com/viur-framework/server/pull/98))
 - Search for templates in the correct path if the htmlpath has been overridden by the class variable. ([#108](https://github.com/viur-framework/server/pull/108))

--- a/db.py
+++ b/db.py
@@ -209,7 +209,7 @@ def GetOrInsert( key, kindName=None, parent=None, **kwargs ):
 
 	def txn( key, kwargs ):
 		try:
-			res = datastore.Get( key )
+			res = Entity.FromDatastoreEntity(datastore.Get( key ))
 		except datastore_errors.EntityNotFoundError:
 			res = Entity( kind=key.kind(), parent=key.parent(), name=key.name(), id=key.id() )
 			for k, v in kwargs.items():


### PR DESCRIPTION
This bug can cause consinstency issues with the datastore if an entry is fetched with
GetOrInsert and then later modified and written back to the datastore with db.Put.
In this case, the old version of this entry is not beeing removed from the memcache
and thus returned in subsequent db.Get() calls. This does not happen if the entry is exclusivly read
with GetOrInsert becorse GetOrInsert will run in a transaction (in which the memcache is never accessed).