### PR TITLE
fixed hierarchy clone method

### DIFF
--- a/prototypes/hierarchy.py
+++ b/prototypes/hierarchy.py
@@ -730,14 +730,7 @@ class Hierarchy(BasicApplication):
 			skel = self.addSkel()
 			skel.fromDB(old_key)
 
-			for k, v in skel.items():
-				logging.debug("BEFORE %s = >%s<", k, skel[k])
-
 			skel = skel.clone()
-			# skel.setValues( {}, key=None )
-
-			for k, v in skel.items():
-				logging.debug("BEHIND %s = >%s<", k, skel[k])
 
 			skel["key"] = None
 			skel["parententry"] = toParent

--- a/prototypes/hierarchy.py
+++ b/prototypes/hierarchy.py
@@ -731,13 +731,13 @@ class Hierarchy(BasicApplication):
 			skel.fromDB(old_key)
 
 			for k, v in skel.items():
-				logging.debug("BEFORE %s = >%s<", (k, skel[k]))
+				logging.debug("BEFORE %s = >%s<", k, skel[k])
 
 			skel = skel.clone()
 			# skel.setValues( {}, key=None )
 
 			for k, v in skel.items():
-				logging.debug("BEHIND %s = >%s<", (k, skel[k]))
+				logging.debug("BEHIND %s = >%s<", k, skel[k])
 
 			skel["key"] = None
 			skel["parententry"] = toParent


### PR DESCRIPTION
Due to a mistake in the logging arguments the recursive clone method of the hierarchy module wouldn't work.
I removed the entire debugging part.