### PR TITLE
Let file/getUploadURL correctly check if uploading a file is allowed into a given node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This file documents any relevant changes done to ViUR server since version 2.
 
 ## [develop] - Current development version
 
+### Fixed
+
+-  file/getUploadURL correctly checks if uploading a file is allowed for a given node
 
 ## [2.5.0] Vesuv - 2019-06-07
 

--- a/modules/file.py
+++ b/modules/file.py
@@ -173,12 +173,13 @@ class File(Tree):
 				skel.delete()
 
 	@exposed
-	def getUploadURL( self, *args, **kwargs ):
-		skey = kwargs.get("skey", "")
-		if not self.canAdd("leaf", None):
+	def getUploadURL(self, node=None, skey=None, *args, **kwargs):
+		if not self.canAdd("leaf", node):
 			raise errors.Forbidden()
+
 		if not securitykey.validate(skey):
 			raise errors.PreconditionFailed()
+
 		return blobstore.create_upload_url("%s/upload" % self.modulePath)
 
 	@internalExposed


### PR DESCRIPTION
This feature works only combination with an extension for Vi, but is backward-compatible if no node is provided.

It should be candidate for v2.5.1