### PR TITLE
Correctly call bound PeriodicTask functions

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -176,12 +176,14 @@ class TaskHandler:
 						continue
 				except db.EntityNotFoundError:
 					pass
+
 			res = self.findBoundTask( task )
+
 			if res: #Its bound, call it this way :)
-				t, s = res
-				t( s )
+				res[0]()
 			else:
 				task() #It seems it wasnt bound - call it as a static method
+
 			logging.debug("Successfully called task %s" % task.periodicTaskName )
 			if intervall:
 				# Update its last-call timestamp


### PR DESCRIPTION
Hi!

I wondered why my parameter "kinds" in this PeriodicTask-decorated function of my backup-module always contained the module's instance instead of the expected None value:
```python
	@PeriodicTask(24 * 60)
	def backup(self, kinds=None, *args, **kwargs):
		logging.info("kinds = %r", kinds)

		if kinds is None:
			kinds = metadata.get_kinds()
		else:
			kinds = kinds.split(",") # Error 500 raised!
```
So I found out that the "bound method calling" in tasks.py is incorrect, so this fix should be better. Most PeriodicTask used in our projects do just throw away any parameter with *args, **kwargs, but here this isn't the case.